### PR TITLE
Move clearTracks to just before redrawing them

### DIFF
--- a/static/js/annotation.js
+++ b/static/js/annotation.js
@@ -23,7 +23,6 @@ class Annotation extends Track {
     this.sourceList = document.getElementById('source-list');
     this.sourceList.addEventListener('change', () => {
       this.expanded = false;
-      this.clearTracks;
       this.drawTracks(document.getElementById('region_field').value);
     })
     this.annotSourceList();
@@ -74,6 +73,8 @@ class Annotation extends Track {
       let latest_height = 0; // Latest height order for annotation
       let latest_name_end = 0; // Latest annotations end position
       let latest_track_end = 0; // Latest annotations title's end position
+
+      this.clearTracks();
 
       // Go through results and draw appropriate symbols
       for (let i = 0; i < result['annotations'].length; i++) {

--- a/static/js/interactive.js
+++ b/static/js/interactive.js
@@ -337,10 +337,6 @@ class InteractiveCanvas {
 
     this.drawInteractiveContent();
 
-    // Clear tracks and annotations
-    tc.clearTracks();
-    ac.clearTracks();
-
     // Draw new tracks and annotations
     tc.drawTracks(this.inputField.value);
     ac.drawTracks(this.inputField.value);

--- a/static/js/track.js
+++ b/static/js/track.js
@@ -44,7 +44,7 @@ class Track {
 
         // Toggle between expanded/collapsed view
         this.expanded = !this.expanded;
-        this.clearTracks();
+
         this.drawTracks(inputField.value);
       }, false);
   }

--- a/static/js/transcript.js
+++ b/static/js/transcript.js
@@ -36,6 +36,8 @@ class Transcript extends Track {
       let latest_name_end = 0; // Latest annotations end position
       let latest_track_end = 0; // Latest annotations title's end position
 
+      this.clearTracks();
+
       // Go through results and draw appropriate symbols
       for (let i = 0; i < result['transcripts'].length; i++) {
         const track = result['transcripts'][i];


### PR DESCRIPTION
Makes things appear smoother since the database fetch takes
a couple 100 ms, during which the tracks were empty creating a
flickering feeling.