### PR TITLE
Adjust position and size of the loadingDiv to avoid covering borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - Described Gens APIs in openAPI specification file
  - Add possibility to load overview data from a JSON, which substantially improves initial load times.
  - Ctrl + Mouse click in interacive canvas zooms out
- - Shift + Mouse to select a region in the interactive canvas to zoom in on
+- Shift + Mouse to select a region in the interactive canvas to zoom in on
 ### Changed
  - Added description on how to use the containerized version of Gens
  - Replaced print statements with logging to stderr
@@ -29,7 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - Removed select region to zoom functionality from overview canvas
 ### Fixed
  - Replaced depricated `update()` with `update_one()` in `update_transcripts.py`.
-
+ - Adjust the "Loading..." div to avoid drawing it above UI elements
 ## [1.0.0]
 ### Added
  - Initial release of Gens

--- a/gens/static/js/interactive.js
+++ b/gens/static/js/interactive.js
@@ -106,10 +106,10 @@ class InteractiveCanvas extends FrequencyTrack {
 
     // Setup loading div dimensions
     this.loadingDiv = document.getElementById("loading-div")
-    this.loadingDiv.style.width = (this.plotWidth-1)+"px";
+    this.loadingDiv.style.width = (this.plotWidth-2.5)+"px";
     this.loadingDiv.style.left = (3+this.x)+"px";
     this.loadingDiv.style.top = (56+1+this.y)+"px"; //56 is size of header bar.
-    this.loadingDiv.style.height = (2*this.plotHeight-1)+"px";
+    this.loadingDiv.style.height = (2*this.plotHeight-2.5)+"px";
 
     // Initialize marker div
     this.markerElem = document.getElementById('interactive-marker');

--- a/gens/static/js/interactive.js
+++ b/gens/static/js/interactive.js
@@ -106,10 +106,10 @@ class InteractiveCanvas extends FrequencyTrack {
 
     // Setup loading div dimensions
     this.loadingDiv = document.getElementById("loading-div")
-    this.loadingDiv.style.width = this.plotWidth+"px";
-    this.loadingDiv.style.left = (1+this.x)+"px";
-    this.loadingDiv.style.top = (32+1+this.y)+"px"; //32 is size of header bar.
-    this.loadingDiv.style.height = (2*this.plotHeight)+"px";
+    this.loadingDiv.style.width = (this.plotWidth-1)+"px";
+    this.loadingDiv.style.left = (3+this.x)+"px";
+    this.loadingDiv.style.top = (56+1+this.y)+"px"; //56 is size of header bar.
+    this.loadingDiv.style.height = (2*this.plotHeight-1)+"px";
 
     // Initialize marker div
     this.markerElem = document.getElementById('interactive-marker');


### PR DESCRIPTION
This adjusts the size and position of the "Loading..." div to avoid drawing it above UI stuff.

Lots of magic numbers, but meh...