### PR TITLE
Fix missing gene names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - Changed positive strand color of transcripts to a more constrasting color
  - Temporarily disabled on hover popups in annotation tracks
  - Transcripts are represented as arrows in lower resolutions
+ - Highlight MANE transcript in name and with a brighter color
 ### Fixed
  - Gene names are now centered below transcript
  - Fixed assignement of height order when updating transcript data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 ### Changed
+ - Changed positive strand color of transcripts to a more constrasting color
+ - Temporarily disabled on hover popups in annotation tracks
+ - Transcripts are represented as arrows in lower resolutions
 ### Fixed
+ - Gene names are now centered below transcript
+ - Fixed assignement of height order when updating transcript data
 
 ## [1.1.2]
 ### Added

--- a/assets/js/annotation.js
+++ b/assets/js/annotation.js
@@ -142,7 +142,7 @@ class Annotation extends Track {
 
       const textYPos = this.tracksYPos(heightOrder);
       // limit drawing of titles to certain resolution
-      if ( this.getResolution < 5) {
+      if ( this.getResolution < 6) {
         // Draw annotation name
         this.heightOrderRecord.latestNameEnd = this.drawText(
           annotationName,

--- a/assets/js/annotation.js
+++ b/assets/js/annotation.js
@@ -168,14 +168,14 @@ chr${chrom}:${start}-${end}
 Score = ${score}`;
 
       // Add tooltip title for whole gene
-      this.heightOrderRecord.latestTrackEnd = this.hoverText(
-        geneText,
-        `${scale * (start - this.trackData.start_pos)}px`,
-        `${textYPos - this.featureHeight / 2}px`,
-        `${scale * (end - start)}px`,
-        `${this.featureHeight + textSize}px`,
-        0,
-        this.heightOrderRecord.latestHeight);
+      // this.heightOrderRecord.latestTrackEnd = this.hoverText(
+      //   geneText,
+      //   `${scale * (start - this.trackData.start_pos)}px`,
+      //   `${textYPos - this.featureHeight / 2}px`,
+      //   `${scale * (end - start)}px`,
+      //   `${this.featureHeight + textSize}px`,
+      //   0,
+      //   this.heightOrderRecord.latestHeight);
     }
   }
 }

--- a/assets/js/track.js
+++ b/assets/js/track.js
@@ -1,5 +1,31 @@
 // Generic functions related to annotation tracks
 
+// function for shading and blending colors on the fly
+const pSBC=(p,c0,c1,l)=>{
+    let r,g,b,P,f,t,h,i=parseInt,m=Math.round,a=typeof(c1)=="string";
+    if(typeof(p)!="number"||p<-1||p>1||typeof(c0)!="string"||(c0[0]!='r'&&c0[0]!='#')||(c1&&!a))return null;
+    if(!this.pSBCr)this.pSBCr=(d)=>{
+        let n=d.length,x={};
+        if(n>9){
+            [r,g,b,a]=d=d.split(","),n=d.length;
+            if(n<3||n>4)return null;
+            x.r=i(r[3]=="a"?r.slice(5):r.slice(4)),x.g=i(g),x.b=i(b),x.a=a?parseFloat(a):-1
+        }else{
+            if(n==8||n==6||n<4)return null;
+            if(n<6)d="#"+d[1]+d[1]+d[2]+d[2]+d[3]+d[3]+(n>4?d[4]+d[4]:"");
+            d=i(d.slice(1),16);
+            if(n==9||n==5)x.r=d>>24&255,x.g=d>>16&255,x.b=d>>8&255,x.a=m((d&255)/0.255)/1000;
+            else x.r=d>>16,x.g=d>>8&255,x.b=d&255,x.a=-1
+        }return x};
+    h=c0.length>9,h=a?c1.length>9?true:c1=="c"?!h:false:h,f=this.pSBCr(c0),P=p<0,t=c1&&c1!="c"?this.pSBCr(c1):P?{r:0,g:0,b:0,a:-1}:{r:255,g:255,b:255,a:-1},p=P?p*-1:p,P=1-p;
+    if(!f||!t)return null;
+    if(l)r=m(P*f.r+p*t.r),g=m(P*f.g+p*t.g),b=m(P*f.b+p*t.b);
+    else r=m((P*f.r**2+p*t.r**2)**0.5),g=m((P*f.g**2+p*t.g**2)**0.5),b=m((P*f.b**2+p*t.b**2)**0.5);
+    a=f.a,t=t.a,f=a>=0||t>=0,a=f?a<0?t:t<0?a:a*P+t*p:0;
+    if(h)return"rgb"+(f?"a(":"(")+r+","+g+","+b+(f?","+m(a*1000)/1000:"")+")";
+    else return"#"+(4294967296+r*16777216+g*65536+b*256+(f?m(a*255):0)).toString(16).slice(1,f?undefined:-2)
+}
+
 // Check if two geometries are overlapping
 // each input is an object with start/ end coordinates
 // f          >----------------<

--- a/assets/js/track.js
+++ b/assets/js/track.js
@@ -229,15 +229,12 @@ class Track {
     this.drawCtx.strokeStyle = color;
     this.drawCtx.lineWidth = lineWidth;
     this.drawCtx.beginPath();
-    console.log(`Move pointer to: ${xStart}, ${yPos}`)
     this.drawCtx.moveTo(xStart, yPos);  // begin at bottom left
     const waveLength = 2 * (height / Math.tan(45));
     const lineLength = xStop - xStart + 1;
-    console.log(`Start pos: ${xStart}, ${yPos}; Height: ${height}; WaveLength: ${waveLength}; Line len: ${lineLength}`)
     // plot whole wave pattern
     let midline = yPos - height / 2 // middle of line
     let lastXpos = xStart;
-    console.log(`Plot ${Math.floor(lineLength / (waveLength / 2))} full wave pattens`)
     for (let i = 0; i < Math.floor(lineLength / (waveLength / 2)); i++){
       lastXpos += waveLength / 2;
       height *= -1  // reverse sign
@@ -249,7 +246,6 @@ class Track {
       height *= -1  // reverse sign
       let partialWaveHeight = partialWaveLength * Math.tan(45);
       this.drawCtx.lineTo(xStop, yPos - Math.sign(height) * partialWaveHeight);
-      console.log(`Plot partial wave: ${partialWaveHeight}; Height: ${height}`)
     }
     this.drawCtx.stroke();
     this.drawCtx.restore();

--- a/assets/js/track.js
+++ b/assets/js/track.js
@@ -285,11 +285,11 @@ class Track {
   // Draw an arrow in desired direction
   // Forward arrow: direction = 1
   // Reverse arrow: direction = -1
-  async drawArrow (xpos, ypos, direction, height, color) {
+  async drawArrow (xpos, ypos, direction, height, lineWidth=2, color) {
     let width = direction * this.arrowWidth;
     this.drawCtx.save();
     this.drawCtx.strokeStyle = color;
-    this.drawCtx.lineWidth = this.arrowThickness;
+    this.drawCtx.lineWidth = lineWidth;
     this.drawCtx.beginPath();
     this.drawCtx.moveTo(xpos - width / 2, ypos - height / 2);
     this.drawCtx.lineTo(xpos + width / 2, ypos);

--- a/assets/js/transcript.js
+++ b/assets/js/transcript.js
@@ -200,6 +200,7 @@ class Transcript extends Track {
 
     // Go through queryResults and draw appropriate symbols
     const drawGeneName = this.getResolution < 3;
+    const drawExons = this.getResolution < 4;
     for ( let transc of filteredTranscripts ) {
       if (!this.expanded && transc.height_order != 1)
         continue
@@ -212,7 +213,7 @@ class Transcript extends Track {
         transc, queryResult, color,
         plotFormat,
         drawGeneName,  // if gene names should be drawn
-        !drawGeneName, // if transcripts should be represented as arrows
+        !drawExons, // if transcripts should be represented as arrows
       );
     }
   }

--- a/assets/js/transcript.js
+++ b/assets/js/transcript.js
@@ -71,7 +71,7 @@ class Transcript extends Track {
     const textSize = plotFormat.textSize;
     const titleMargin = plotFormat.titleMargin;
     // lighten colors for MANE transcripts
-    let elementColor = element.mane ? pSBC(0.3, color) : color;
+    let elementColor = element.mane ? pSBC(0.25, color) : color;
 
     // Keep track of latest track
     if ( this.heightOrderRecord.latestHeight != element.height_order ) {

--- a/assets/js/transcript.js
+++ b/assets/js/transcript.js
@@ -110,7 +110,7 @@ chr ${queryResult.chromosome}:${feature.start}-${feature.end}`;
     const textYPos = this.tracksYPos(element.height_order);
     this.heightOrderRecord.latestNameEnd = this.drawText(
       geneName,
-      scale * ((displayedTrStart + displayedTrEnd) / 2 - this.offscreenPosition.start),
+      ((displayedTrEnd - displayedTrStart) / 2) + displayedTrStart,
       textYPos + this.featureHeight,
       textSize,
       this.heightOrderRecord.latestNameEnd);

--- a/assets/js/transcript.js
+++ b/assets/js/transcript.js
@@ -50,19 +50,19 @@ class Transcript extends Track {
       latestFeaturePos = feature.end;
       // Draw the geometry that represents the feature
       if ( feature.feature == 'exon') {
-        const exonText = `${geneText}
-${"-".repeat(30)}
-Exon number: ${feature.exon_number}
-chr ${queryResult.chromosome}:${feature.start}-${feature.end}`;
         // Add tooltip title for whole gene
-        this.heightOrderRecord.latestTrackEnd = this.hoverText(
-          exonText,
-          `${titleMargin + scale * (feature.start - queryResult.queryStart)}px`,
-          `${titleMargin + textYPos - (this.featureHeight / 2)}px`,
-          `${scale * (feature.end - feature.start)}px`,
-          `${this.featureHeight}px`,
-          1,
-          this.heightOrderRecord.latestTrackEnd);
+        // const exonText = `${geneText}
+// ${"-".repeat(30)}
+// Exon number: ${feature.exon_number}
+// chr ${queryResult.chromosome}:${feature.start}-${feature.end}`;
+        // this.heightOrderRecord.latestTrackEnd = this.hoverText(
+        //   exonText,
+        //   `${titleMargin + scale * (feature.start - queryResult.queryStart)}px`,
+        //   `${titleMargin + textYPos - (this.featureHeight / 2)}px`,
+        //   `${scale * (feature.end - feature.start)}px`,
+        //   `${this.featureHeight}px`,
+        //   1,
+        //   this.heightOrderRecord.latestTrackEnd);
         this.drawBox(
           scale * (feature.start - this.offscreenPosition.start),
           canvasYPos, scale * (feature.end - feature.start),
@@ -125,14 +125,15 @@ chr ${queryResult.chromosome}:${feature.start}-${feature.end}`;
       `id = ${transcriptID}`;
     }
     // Add tooltip title for whole gene
-    this.heightOrderRecord.latestTrackEnd = this.hoverText(
-      geneText,
-      `${titleMargin + scale * (trStart - queryResult.start_pos)}px`,
-      `${titleMargin + textYPos - this.featureHeight / 2}px`,
-      `${scale * (trEnd - trStart)}px`,
-      `${this.featureHeight + textSize}px`,
-      0,
-      this.heightOrderRecord.latestTrackEnd);
+    // this.heightOrderRecord.latestTrackEnd = this.hoverText(
+    //   geneText,
+    //   `${titleMargin + displayedTrStart}px`,
+    //   `${titleMargin + textYPos - this.featureHeight / 2}px`,
+    //   `${displayedTrEnd - displayedTrStart + 1}px`,
+    //   `${this.featureHeight + textSize}px`,
+    //   0,
+    //   this.heightOrderRecord.latestTrackEnd
+    // );
     return geneText;
   }
 

--- a/assets/js/variant.js
+++ b/assets/js/variant.js
@@ -155,15 +155,15 @@ class Variant extends Track {
                         `Rank score: ${rankScore}\n`;
 
       // Add tooltip title for whole gene
-      this.heightOrderRecord.latestTrackEnd = this.hoverText(
-        variantText,
-        `${titleMargin + scale * (variantStart - this.offscreenPosition.start)}px`,
-        `${titleMargin + textYPos - this.featureHeight / 2}px`,
-        `${scale * (variantEnd - variantStart)}px`,
-        `${this.featureHeight + textSize}px`,
-        0,
-        this.heightOrderRecord.latestTrackEnd
-      );
+      // this.heightOrderRecord.latestTrackEnd = this.hoverText(
+      //   variantText,
+      //   `${titleMargin + scale * (variantStart - this.offscreenPosition.start)}px`,
+      //   `${titleMargin + textYPos - this.featureHeight / 2}px`,
+      //   `${scale * (variantEnd - variantStart)}px`,
+      //   `${this.featureHeight + textSize}px`,
+      //   0,
+      //   this.heightOrderRecord.latestTrackEnd
+      // );
     }
   }
 }

--- a/gens/config.py
+++ b/gens/config.py
@@ -14,5 +14,5 @@ DEFAULT_ANNOTATION_TRACK = (
 # UI colors
 UI_COLORS = {
     "variants": {"del": "#C84630", "dup": "#4C6D94"},
-    "transcripts": {"strand_pos": "#4D908E", "strand_neg": "#43AA8B"},
+    "transcripts": {"strand_pos": "#aa4362", "strand_neg": "#43AA8B"},
 }

--- a/utils/update_transcripts.py
+++ b/utils/update_transcripts.py
@@ -7,14 +7,19 @@ import argparse
 import csv
 import os
 from functools import cmp_to_key
+from itertools import groupby
 
 from pymongo import ASCENDING, MongoClient
 
 from gtfparse import read_gtf
+import logging
+import click
+
+LOG = logging.getLogger(__name__)
 
 host = os.environ.get("MONGODB_HOST", "10.0.224.63")
 port = int(os.environ.get("MONGODB_PORT", 27017))
-print(f"connecting to db: {port}:{host}")
+LOG.info(f"connecting to db: {port}:{host}")
 CLIENT = MongoClient(
     host=host,
     port=port,
@@ -51,6 +56,7 @@ class UpdateTranscripts:
         self.collection.create_index([("height_order", ASCENDING)], unique=False)
         self.collection.create_index("hg_type", unique=False)
 
+        LOG.info('Indexing MANE transcripts')
         # Set MANE transcripts
         with open(self.mane_file) as mane_file:
             cs_reader = csv.reader(mane_file, delimiter="\t")
@@ -62,50 +68,32 @@ class UpdateTranscripts:
                 self.mane[ensemble_nuc] = {"hgnc_id": hgnc_id, "refseq_id": refseq_id}
 
         # Set the rest
+        LOG.info('Sorting transcript file')
         with open(self.input_file) as track_file:
             tracks = read_gtf(track_file)
-            tracks = [
-                list(a)
-                for a in zip(
-                    tracks["seqname"],
-                    tracks["gene_name"],
-                    tracks["feature"],
-                    tracks["start"],
-                    tracks["end"],
-                    tracks["strand"],
-                    tracks["transcript_id"],
-                    tracks["transcript_biotype"],
-                    tracks["exon_number"],
-                )
-            ]
 
-            # Sort transcripts to the top, also sort tracks belonging to the same gene
+        # Variables for setting height order of track
+        previous_gene_name = ""
+        height_order = 1
+
+        results = {}
+        features = {}
+
+        LOG.info('Parsing transcripts')
+        # Insert tracks in DB
+        gr_tracks = groupby(tracks.iterrows(), key=lambda tr: tr[1]['gene_name'])
+        for gene_name, gene_tracks in gr_tracks:
+            tracks = list(gene_tracks)
             tracks.sort(key=cmp_to_key(self.track_sorter))
-
-            # Variables for setting height order of track
-            previous_gene_name = ""
-            height_order = 1
-
-            features = {}
-
-            # Insert tracks in DB
-            for (
-                seqname,
-                gene_name,
-                feature,
-                start,
-                end,
-                strand,
-                transcript_id,
-                transcript_biotype,
-                exon_number,
-            ) in tracks:
-
-                if transcript_biotype != "protein_coding":
+            for track in tracks:
+                track = track[1]
+                transcript_id = track['transcript_id']
+                biotype = track['transcript_biotype']
+                if not biotype == "protein_coding":
                     continue
 
-                if feature == "transcript":
-                    if gene_name != previous_gene_name:
+                if track['feature'] == "transcript":
+                    if not track['gene_name'] == previous_gene_name:
                         height_order = 1
                     else:
                         height_order += 1
@@ -120,69 +108,66 @@ class UpdateTranscripts:
                         refseq_id = None
 
                     mane = True if transcript_id in self.mane else False
-                    self.temp_collection.insert_one(
-                        {
-                            "chrom": seqname,
-                            "hg_type": int(self.hg_type),
-                            "gene_name": gene_name,
-                            "start": start,
-                            "end": end,
-                            "strand": strand,
-                            "height_order": height_order,
-                            "transcript_id": transcript_id,
-                            "transcript_biotype": transcript_biotype,
-                            "mane": mane,
-                            "hgnc_id": hgnc_id,
-                            "refseq_id": refseq_id,
-                            "features": [],
-                        }
-                    )
+                    results[transcript_id] = {
+                        "chrom": track['seqname'],
+                        "hg_type": int(self.hg_type),
+                        "gene_name": gene_name,
+                        "start": track['start'],
+                        "end": track['end'],
+                        "strand": track['strand'],
+                        "height_order": height_order,
+                        "transcript_id": transcript_id,
+                        "transcript_biotype": biotype,
+                        "mane": mane,
+                        "hgnc_id": hgnc_id,
+                        "refseq_id": refseq_id,
+                        "features": [],
+                    }
                     previous_gene_name = gene_name
                 else:
                     # Gather features for a bulk update
                     features.setdefault(transcript_id, []).append(
                         {
-                            "feature": feature,
-                            "exon_number": exon_number,
-                            "start": start,
-                            "end": end,
+                            "feature": track['feature'],
+                            "exon_number": track['exon_number'],
+                            "start": track['start'],
+                            "end": track['end'],
                         }
                     )
 
-            # Bulk update transcripts with features
-            for transcript_id in features:
-                self.temp_collection.update_one(
-                    {"transcript_id": transcript_id},
-                    {"$set": {"features": features[transcript_id]}},
-                )
+        # Bulk update transcripts with features
+        for transcript_id, tr_features in features.items():
+            results[transcript_id]['features'] = tr_features
+            """
+            self.temp_collection.update_one(
+                {"transcript_id": transcript_id},
+                {"$set": {"features": features[transcript_id]}},
+            )
+            """
+        # Bulk insert collections
+        self.temp_collection.insert_many(list(results.values()))
 
-    def track_sorter(self, track1, track2):
+    def track_sorter(self, tr1, tr2):
         """
         Sorts a track depending on feature, gene name and start position
-        """
-        t1_gene_name = track1[1]
-        t2_gene_name = track2[1]
-        t1_feature = track1[2]
-        t2_feature = track2[2]
-        t1_start = track1[3]
-        t2_start = track2[3]
-        t1_transcript_id = track1[6]
-        t2_transcript_id = track2[6]
 
-        # Sort by:
-        # 1) Transcript headers
-        # 2) MANE transcripts
-        # 3) Both are transcripts: sort by gene name and start position
+        Sort by:
+        1) Transcript headers
+        2) MANE transcripts
+        3) Both are transcripts: sort by gene name and start position
+        """
+        tr1 = tr1[1]
+        tr2 = tr2[1]
         if (
-            (t1_feature == "transcript" and t2_feature != "transcript")
-            or t1_transcript_id in self.mane
-            or (t1_gene_name == t2_gene_name and t1_start < t2_start)
+            (tr1['feature'] == "transcript" and tr2['feature'] != "transcript")
+            or tr1['transcript_id'] in self.mane
+            or (tr1['gene_name'] == tr2['gene_name'] and tr1['start'] < tr2['start'])
         ):
             return -1
         if (
-            (t1_feature != "transcript" and t2_feature == "transcript")
-            or t2_transcript_id in self.mane
-            or (t1_gene_name == t2_gene_name and t1_start > t2_start)
+            (tr1['feature'] != "transcript" and tr2['feature'] == "transcript")
+            or tr2['transcript_id'] in self.mane
+            or (tr1['gene_name'] == tr2['gene_name'] and tr1['start'] > tr2['start'])
         ):
             return 1
         return 0
@@ -231,17 +216,17 @@ def main():
     )
     args = parser.parse_args()
 
-    print("Updating transcripts")
+    LOG.info("Updating transcripts")
     update = UpdateTranscripts(args)
     try:
         update.write_transcripts()
     except Exception as e:
-        print(str(e))
-        print("Error, could not update. Rollback")
+        LOG.error(str(e))
+        LOG.error("Error, could not update. Rollback")
         update.clean_up()
         return
     update.save_to_collection()
-    print("Finished updating transcripts")
+    LOG.info("Finished updating transcripts")
 
 
 if __name__ == "__main__":

--- a/utils/update_transcripts.py
+++ b/utils/update_transcripts.py
@@ -138,12 +138,6 @@ class UpdateTranscripts:
         # Bulk update transcripts with features
         for transcript_id, tr_features in features.items():
             results[transcript_id]['features'] = tr_features
-            """
-            self.temp_collection.update_one(
-                {"transcript_id": transcript_id},
-                {"$set": {"features": features[transcript_id]}},
-            )
-            """
         # Bulk insert collections
         self.temp_collection.insert_many(list(results.values()))
 


### PR DESCRIPTION
This PR fixes issues relating to rendering of transcripts in Gens. 

**How to test**:
1. Clone and setup a new dev environment of Gens
2. Load transcripts using the command, `./utils/update_transcripts.py --file /home/app/data/Homo_sapiens.GRCh38.101.gtf --mane /home/app/data/MANE.GRCh38.v0.92.summary.txt`
3. Navigate to, http://10.0.224.64:5003/643594?region=21:25582700-25611507
4. Navigate to, http://10.0.224.64:5003/643594?region=1:920355-961815

**Expected outcome**:
1. Gene names should be centered under the displayed portion of the transcript
2. Transcripts on forward and reverse strand should be indicated with different colors
3. MANE transcript should be marked with a brighter color and have MANE in its name

**Review:**
- [ ] code approved by
