### PR TITLE
Fix missing variant api crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - Temporarily disabled on hover popups in annotation tracks
  - Transcripts are represented as arrows in lower resolutions
  - Highlight MANE transcript in name and with a brighter color
+ - Annotaion tracks are disabled if api returns an error at some point
 ### Fixed
  - Gene names are now centered below transcript
  - Fixed assignement of height order when updating transcript data
+ - get-variant-data returns 404 if case cant be found
 
 ## [1.1.2]
 ### Added

--- a/assets/css/error.scss
+++ b/assets/css/error.scss
@@ -42,7 +42,7 @@
 
     .error-msg-container {
         position: absolute;
-        top: 110%;
+        top: 500px;
         width: 40%;
         border-radius: 4px;
         padding: 20px;

--- a/gens/api.py
+++ b/gens/api.py
@@ -202,7 +202,6 @@ def search_annotation(query: str, hg_type, annotation_type):
 
 def get_variant_data(sample_id, variant_category, **optional_kwargs):
     """Search Scout database for variants associated with a case and return info in JSON format."""
-    abort(404)
     default_height_order = 0
     base_return = {"status": "ok"}
     # get optional variables

--- a/gens/api.py
+++ b/gens/api.py
@@ -202,6 +202,7 @@ def search_annotation(query: str, hg_type, annotation_type):
 
 def get_variant_data(sample_id, variant_category, **optional_kwargs):
     """Search Scout database for variants associated with a case and return info in JSON format."""
+    abort(404)
     default_height_order = 0
     base_return = {"status": "ok"}
     # get optional variables
@@ -224,13 +225,16 @@ def get_variant_data(sample_id, variant_category, **optional_kwargs):
         }
         # limit renders to b or greater resolution
     # query variants
-    variants = list(
-        query_variants(
-            sample_id,
-            cattr.structure(variant_category, VariantCategory),
-            **region_params,
+    try:
+        variants = list(
+            query_variants(
+                sample_id,
+                cattr.structure(variant_category, VariantCategory),
+                **region_params,
+            )
         )
-    )
+    except ValueError as err:
+        abort(404, str(err))
     # return all detected variants
     return (
         jsonify(

--- a/gens/blueprints/gens/templates/gens.html
+++ b/gens/blueprints/gens/templates/gens.html
@@ -132,7 +132,8 @@
     const inputField = document.getElementById('region_field');
 
     // Set first input field value for ic
-    inputField.value = '{{chrom}}' + ':' + {{start}} + '-' + {{end}};
+    let start = {{ start }} == 0 ? 1 : {{ start }};
+    inputField.value = '{{chrom}}' + ':' + start + '-' + {{end}};
     inputField.placeholder = inputField.value;
 
     // Hide non-rendered content

--- a/gens/db/db.py
+++ b/gens/db/db.py
@@ -50,12 +50,12 @@ def query_variants(case_name: str, variant_category: VariantCategory, **kwargs):
     """
     # lookup case_id from the displayed name
     db = app.config["SCOUT_DB"]
-    case_id = db.case.find_one({"display_name": case_name})["_id"]
-    if case_id is None:
+    response = db.case.find_one({"display_name": case_name})
+    if response is None:
         raise ValueError(f"No case with name: {case_name}")
     # build query
     query = {
-        "case_id": case_id,
+        "case_id": response["_id"],
         "category": variant_category.value,
     }
     # add chromosome


### PR DESCRIPTION
This PR fixes an instance where Gens api crashed when querying for variants from a case not in Scout db. It disables an annotation track if the data could not be fetched. 

**Review:**
- [ ] code approved by
