### PR TITLE
Use template macros for annotation tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
  - Transcripts are represented as arrows in lower resolutions
  - Highlight MANE transcript in name and with a brighter color
  - Annotaion tracks are disabled if api returns an error at some point
+ - Annotation track DOMs are constructed with template macros
 ### Fixed
  - Gene names are now centered below transcript
  - Fixed assignement of height order when updating transcript data

--- a/gens/blueprints/gens/templates/gens.html
+++ b/gens/blueprints/gens/templates/gens.html
@@ -1,6 +1,14 @@
 <!-- GENS overview template -->
 {% import 'info.html' as info %}
 
+{% macro annotation_track(track_name) %}
+    <div id='{{ track_name }}-container' class='info-container'>
+        <canvas id='{{ track_name }}-content' class='info-canvas'></canvas>
+        <canvas id='{{ track_name }}-draw' class='info-canvas offscreen'></canvas>
+        <div id='{{ track_name }}-titles' class='info-titles'></div>
+    </div>
+{% endmacro %}
+
 {% extends "layout.html" %}
 {% block title %}Visualization{% endblock title %}
 {% block css_style %}
@@ -58,23 +66,9 @@
                 <div id='loading-div'>LOADING...</div>
             </div>
 
-            <div id='variant-container' class='info-container'>
-                <canvas id='variant-content' class='info-canvas'></canvas>
-                <canvas id='variant-draw' class='info-canvas offscreen'></canvas>
-                <div id='variant-titles' class='info-titles'></div>
-            </div>
-
-            <div id='transcript-container' class='info-container'>
-                <canvas id='transcript-content' class='info-canvas'></canvas>
-                <canvas id='transcript-draw' class='info-canvas offscreen'></canvas>
-                <div id='transcript-titles' class='info-titles'></div>
-            </div>
-
-            <div id='annotation-container' class='info-container'>
-                <canvas id='annotation-content' class='info-canvas'></canvas>
-                <canvas id='annotation-draw' class='info-canvas offscreen'></canvas>
-                <div id='annotation-titles' class='info-titles'></div>
-            </div>
+            {{ annotation_track("variant") }}
+            {{ annotation_track("transcript") }}
+            {{ annotation_track("annotation") }}
 
             <div id='button-container'>
                 <select id='source-list'></select>


### PR DESCRIPTION
This moves annotation tracks in the template to a macro. 

I am not using the macro for `interactive-container`, since it is different at almost every line... 