### PR TITLE
Display annotation information in tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Added
+ - Reinstated tooltips to display additional information on genetic elements
 ### Changed
+ - Use popper for positioning tooltips
 ### Fixed
 
 ## [1.2.0]

--- a/assets/css/gens.scss
+++ b/assets/css/gens.scss
@@ -27,6 +27,36 @@ html, body {
     grid-template-rows: auto;
 }
 
+.tooltip {
+    background: #333;
+    color: white;
+    font-weight: bold;
+    padding: 4px 8px;
+    font-size: 13px;
+    border-radius: 4px;
+    display: none;
+}
+
+.tooltip[data-show] {
+  display: block
+}
+
+.tooltip[data-popper-placement^='top'] > .arrow {
+  bottom: -4px;
+}
+
+.tooltip[data-popper-placement^='bottom'] > .arrow {
+  top: -4px;
+}
+
+.tooltip[data-popper-placement^='left'] > .arrow {
+  right: -4px;
+}
+
+.tooltip[data-popper-placement^='right'] > .arrow {
+  left: -4px;
+}
+
 #loading-div {
     display:none;
     position:absolute;

--- a/assets/css/gens.scss
+++ b/assets/css/gens.scss
@@ -34,6 +34,7 @@ html, body {
     padding: 4px 8px;
     font-size: 13px;
     border-radius: 4px;
+    z-index: 1;
     display: none;
 }
 

--- a/assets/css/gens.scss
+++ b/assets/css/gens.scss
@@ -28,14 +28,22 @@ html, body {
 }
 
 .tooltip {
-    background: #333;
-    color: white;
-    font-weight: bold;
-    padding: 4px 8px;
-    font-size: 13px;
-    border-radius: 4px;
-    z-index: 1;
+  background: #333;
+  color: white;
+  font-weight: bold;
+  padding: 4px 8px;
+  font-size: 13px;
+  border-radius: 4px;
+  z-index: 1;
+  display: none;
+
+  .feature {
     display: none;
+  }
+
+  .feature[data-show] {
+    display: block;
+  }
 }
 
 .tooltip[data-show] {

--- a/assets/js/interactive.js
+++ b/assets/js/interactive.js
@@ -332,7 +332,6 @@ export class InteractiveCanvas extends BaseScatterTrack {
   markRegion ({ start, end }) {
     // Update the dom element
     this.markerElem.style.left = start < end ? `${start}px` : `${end}px`
-    const width = (end - start) + 1 > this.plotWidth ? this.plotWidth : (end - start) + 1
     this.markerElem.style.width = `${Math.abs(end - start) + 1}px`
   }
 
@@ -376,7 +375,6 @@ export class InteractiveCanvas extends BaseScatterTrack {
       (start - this.offscreenPosition.start) * this.offscreenPosition.scale)
     const offscSegmentWidth = Math.round(width * this.offscreenPosition.scale)
     const onscSegmentWidth = width * this.calcScale()
-    const lineMargin = 2
     // clear current canvas
     const ctx = this.contentCanvas.getContext('2d')
     ctx.clearRect(

--- a/assets/js/track/annotation.js
+++ b/assets/js/track/annotation.js
@@ -121,7 +121,7 @@ export class AnnotationTrack extends BaseAnnotationTrack {
     // dont show tracks with no data in them
     if (filteredAnnotations.length > 0) {
       //  Set needed height of visible canvas and transcript tooltips
-      this.setContainerHeight(this.trackData.maxHeightOrder)
+      this.setContainerHeight(this.trackData.max_height_order)
     } else {
       //  Set needed height of visible canvas and transcript tooltips
       this.setContainerHeight(0)

--- a/assets/js/track/annotation.js
+++ b/assets/js/track/annotation.js
@@ -183,7 +183,7 @@ export class AnnotationTrack extends BaseAnnotationTrack {
       })
       // create a tooltip html element and append to DOM
       const tooltip = createTooltipElement({
-        id: `${annotationObj.id}-popover`,
+        id: `popover-${annotationObj.id}`,
         title: annotationObj.name,
         information: [
           { title: track.chrom, value: `${track.start}-${track.end}` },

--- a/assets/js/track/annotation.js
+++ b/assets/js/track/annotation.js
@@ -90,15 +90,15 @@ export class AnnotationTrack extends BaseAnnotationTrack {
   }
 
   // Draws annotations in given range
-  async drawOffScreenTrack (queryResult) {
+  async drawOffScreenTrack ({start_pos, end_pos, max_height_order, data}) {
     const textSize = 10
 
     // store positions used when rendering the canvas
     this.offscreenPosition = {
-      start: queryResult.start_pos,
-      end: queryResult.end_pos,
+      start: start_pos,
+      end: end_pos,
       scale: (this.drawCanvas.width /
-              (queryResult.end_pos - queryResult.start_pos))
+              (end_pos - start_pos))
     }
     const scale = this.offscreenPosition.scale
 
@@ -111,13 +111,12 @@ export class AnnotationTrack extends BaseAnnotationTrack {
     // limit drawing of transcript to pre-defined resolutions
     let filteredAnnotations = []
     if (this.getResolution < this.maxResolution + 1) {
-      filteredAnnotations = queryResult
-        .data
+      filteredAnnotations = data
         .annotations
         .filter(annot => isElementOverlapping(annot,
           {
-            start: queryResult.start_pos,
-            end: queryResult.end_pos
+            start: start_pos,
+            end: end_pos
           }))
     }
     // dont show tracks with no data in them

--- a/assets/js/track/annotation.js
+++ b/assets/js/track/annotation.js
@@ -1,6 +1,7 @@
 // Annotation track definition
 
-import { BaseAnnotationTrack, isElementOverlapping } from './base.js'
+import { BaseAnnotationTrack } from './base.js'
+import { isElementOverlapping } from './utils.js'
 import { get } from '../fetch.js'
 import { parseRegionDesignation } from '../navigation.js'
 import { drawRect, drawText } from '../draw.js'

--- a/assets/js/track/annotation.js
+++ b/assets/js/track/annotation.js
@@ -8,17 +8,16 @@ import { drawRect, drawText } from '../draw.js'
 import { initTrackTooltips, createTooltipElement, makeVirtualDOMElement, updateVisableElementCoordinates } from './tooltip.js'
 import { createPopper } from '@popperjs/core'
 
-
 // Convert to 32bit integer
-function stringToHash(string) {
-  let hash = 0;
-  if (string.length == 0) return hash;
+function stringToHash (string) {
+  let hash = 0
+  if (string.length === 0) return hash
   for (let i = 0; i < string.length; i++) {
-      const char = string.charCodeAt(i);
-      hash = ((hash << 5) - hash) + char;
-      hash = hash & hash;
+    const char = string.charCodeAt(i)
+    hash = ((hash << 5) - hash) + char
+    hash = hash & hash
   }
-  return hash;
+  return hash
 }
 
 export class AnnotationTrack extends BaseAnnotationTrack {
@@ -90,15 +89,15 @@ export class AnnotationTrack extends BaseAnnotationTrack {
   }
 
   // Draws annotations in given range
-  async drawOffScreenTrack ({start_pos, end_pos, max_height_order, data}) {
+  async drawOffScreenTrack ({ startPos, endPos, maxHeightOrder, data }) {
     const textSize = 10
 
     // store positions used when rendering the canvas
     this.offscreenPosition = {
-      start: start_pos,
-      end: end_pos,
+      start: startPos,
+      end: endPos,
       scale: (this.drawCanvas.width /
-              (end_pos - start_pos))
+              (endPos - startPos))
     }
     const scale = this.offscreenPosition.scale
 
@@ -115,14 +114,14 @@ export class AnnotationTrack extends BaseAnnotationTrack {
         .annotations
         .filter(annot => isElementOverlapping(annot,
           {
-            start: start_pos,
-            end: end_pos
+            start: startPos,
+            end: endPos
           }))
     }
     // dont show tracks with no data in them
     if (filteredAnnotations.length > 0) {
       //  Set needed height of visible canvas and transcript tooltips
-      this.setContainerHeight(this.trackData.max_height_order)
+      this.setContainerHeight(this.trackData.maxHeightOrder)
     } else {
       //  Set needed height of visible canvas and transcript tooltips
       this.setContainerHeight(0)
@@ -163,7 +162,7 @@ export class AnnotationTrack extends BaseAnnotationTrack {
         y1: canvasYPos,
         y2: canvasYPos + (this.featureHeight / 2),
         features: [],
-        isDisplayed: false,
+        isDisplayed: false
       }
       // Draw box for annotation
       drawRect({
@@ -188,8 +187,8 @@ export class AnnotationTrack extends BaseAnnotationTrack {
         title: annotationObj.name,
         information: [
           { title: track.chrom, value: `${track.start}-${track.end}` },
-          { title: 'Score', value: `${track.score}` },
-        ],
+          { title: 'Score', value: `${track.score}` }
+        ]
       })
       this.trackContainer.appendChild(tooltip)
       // make a  virtual element as tooltip hitbox
@@ -198,7 +197,7 @@ export class AnnotationTrack extends BaseAnnotationTrack {
         x2: annotationObj.visibleX2,
         y1: annotationObj.visibleY1,
         y2: annotationObj.visibleY2,
-        canvas: this.contentCanvas,
+        canvas: this.contentCanvas
       })
       // add tooltip to annotationObj
       annotationObj.tooltip = {

--- a/assets/js/track/base.js
+++ b/assets/js/track/base.js
@@ -1,6 +1,23 @@
 // Generic functions related to drawing annotation tracks
 
 import { get } from '../fetch.js'
+import {
+  popperGenerator,
+  defaultModifiers,
+} from '@popperjs/core/lib/popper-lite';
+import flip from '@popperjs/core/lib/modifiers/flip';
+import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow';
+
+export const createPopper = popperGenerator({
+  defaultModifiers: [...defaultModifiers, flip, preventOverflow],
+});
+
+
+// check if point is within an element
+export function isWithinElementBbox({element, point}) {
+  return (element.x1 <= point.x && point.x <= element.x2) && (element.y1 <= point.y && point.y <= element.y2)
+}
+
 
 // Check if two geometries are overlapping
 // each input is an object with start/ end coordinates

--- a/assets/js/track/base.js
+++ b/assets/js/track/base.js
@@ -128,9 +128,9 @@ export class BaseAnnotationTrack {
           this.trackContainer.setAttribute('data-state', 'collapsed')
         }
         await this.drawOffScreenTrack({
-          start_pos: this.offscreenPosition.start,
-          end_pos: this.offscreenPosition.end,
-          max_height_order: this.expanded ? this.trackData.max_height_order : 1,
+          startPos: this.offscreenPosition.start,
+          endPos: this.offscreenPosition.end,
+          maxHeightOrder: this.expanded ? this.trackData.max_height_order : 1,
           data: this.trackData
         })
         this.blitCanvas(this.onscreenPosition.start, this.onscreenPosition.end)
@@ -235,9 +235,9 @@ export class BaseAnnotationTrack {
       })
       // draw offscreen position for the first time
       await this.drawOffScreenTrack({
-        start_pos: offscreenPos.start,
-        end_pos: offscreenPos.end,
-        max_height_order: this.trackData.max_height_order,
+        startPos: offscreenPos.start,
+        endPos: offscreenPos.end,
+        maxHeightOrder: this.trackData.max_height_order,
         data: this.trackData
       })
     }

--- a/assets/js/track/base.js
+++ b/assets/js/track/base.js
@@ -3,12 +3,10 @@
 import { get } from '../fetch.js'
 import { hideTooltip } from './tooltip.js'
 
-
 // check if point is within an element
-export function isWithinElementBbox({element, point}) {
-  return (element.x1 <= point.x && point.x <= element.x2) && (element.y1 <= point.y && point.y <= element.y2)
+export function isWithinElementBbox ({ element, point }) {
+  return (element.x1 < point.x && point.x < element.x2) && (element.y1 < point.y && point.y < element.y2)
 }
-
 
 // Check if two geometries are overlapping
 // each input is an object with start/ end coordinates
@@ -98,7 +96,7 @@ export class BaseAnnotationTrack {
 
     // Max resolution
     this.maxResolution = 4
-    this.geneticElements = [] // for tooltips 
+    this.geneticElements = [] // for tooltips
   }
 
   tracksYPos (heightOrder) {

--- a/assets/js/track/base.js
+++ b/assets/js/track/base.js
@@ -3,25 +3,6 @@
 import { get } from '../fetch.js'
 import { hideTooltip } from './tooltip.js'
 
-// check if point is within an element
-export function isWithinElementBbox ({ element, point }) {
-  return (element.x1 < point.x && point.x < element.x2) && (element.y1 < point.y && point.y < element.y2)
-}
-
-// Check if two geometries are overlapping
-// each input is an object with start/ end coordinates
-// f          >----------------<
-// s   >---------<
-export function isElementOverlapping (first, second) {
-  if ((first.start > second.start && first.start < second.end) || //
-       (first.end > second.start && first.end < second.end) ||
-       (second.start > first.start && second.start < first.end) ||
-       (second.end > first.start && second.end < first.end)) {
-    return true
-  }
-  return false
-}
-
 // Calculate offscreen position
 export function calculateOffscreenWindowPos ({ start, end, multiplier }) {
   const width = end - start
@@ -146,7 +127,6 @@ export class BaseAnnotationTrack {
         } else {
           this.trackContainer.setAttribute('data-state', 'collapsed')
         }
-        //  this.drawTrack(inputField.value);
         await this.drawOffScreenTrack({
           chromosome: this.trackData.chromosome,
           start_pos: this.offscreenPosition.start,
@@ -198,27 +178,6 @@ export class BaseAnnotationTrack {
         this.trackContainer.setAttribute('data-state', 'collapsed')
       }
     }
-  }
-
-  // Inserts a hover text for a track
-  hoverText (text, left, top, width, height, zIndex, latestPos) {
-    // Make div wider for more mouse over space
-    const minWidth = 1
-    if (parseInt(width) < minWidth && (parseInt(left) - minWidth / 2) > latestPos) {
-      left = parseInt(left) - minWidth / 2 + 'px'
-      width = minWidth + 'px'
-    }
-
-    const title = document.createElement('div')
-    title.title = text
-    title.style.left = left
-    title.style.top = top
-    title.style.width = width
-    title.style.height = height
-    title.style.position = 'absolute'
-    title.style.zIndex = zIndex
-    this.trackTitle.appendChild(title)
-    return parseInt(left + width)
   }
 
   // Draw annotation track

--- a/assets/js/track/base.js
+++ b/assets/js/track/base.js
@@ -117,7 +117,7 @@ export class BaseAnnotationTrack {
         event.preventDefault()
         // hide all tooltips
         for (const element of this.geneticElements) {
-          hideTooltip(element.tooltip)
+          if (element.tooltip) hideTooltip(element.tooltip)
         }
         // Toggle between expanded/collapsed view
         this.expanded = !this.expanded

--- a/assets/js/track/base.js
+++ b/assets/js/track/base.js
@@ -128,11 +128,8 @@ export class BaseAnnotationTrack {
           this.trackContainer.setAttribute('data-state', 'collapsed')
         }
         await this.drawOffScreenTrack({
-          chromosome: this.trackData.chromosome,
           start_pos: this.offscreenPosition.start,
           end_pos: this.offscreenPosition.end,
-          queryStart: this.onscreenPosition.start,
-          queryEnd: this.onscreenPosition.end, // default to chromosome end
           max_height_order: this.expanded ? this.trackData.max_height_order : 1,
           data: this.trackData
         })
@@ -212,6 +209,7 @@ export class BaseAnnotationTrack {
           collapsed: false // allways get all height orders
         }, this.additionalQueryParams) // parameters specific to track type
       )
+      // disable track if data loading encountered an error
       if (this.trackData.status === 'error') {
         this.trackContainer.parentElement.setAttribute('data-state', 'nodata')
         this.preventDrawingTrack = true
@@ -237,11 +235,8 @@ export class BaseAnnotationTrack {
       })
       // draw offscreen position for the first time
       await this.drawOffScreenTrack({
-        chromosome: this.trackData.chromosome,
         start_pos: offscreenPos.start,
         end_pos: offscreenPos.end,
-        queryStart: start,
-        queryEnd: end || offscreenPos.end, // default to chromosome end
         max_height_order: this.trackData.max_height_order,
         data: this.trackData
       })

--- a/assets/js/track/base.js
+++ b/assets/js/track/base.js
@@ -1,16 +1,7 @@
 // Generic functions related to drawing annotation tracks
 
 import { get } from '../fetch.js'
-import {
-  popperGenerator,
-  defaultModifiers,
-} from '@popperjs/core/lib/popper-lite';
-import flip from '@popperjs/core/lib/modifiers/flip';
-import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow';
-
-export const createPopper = popperGenerator({
-  defaultModifiers: [...defaultModifiers, flip, preventOverflow],
-});
+import { hideTooltip } from './tooltip.js'
 
 
 // check if point is within an element
@@ -107,6 +98,7 @@ export class BaseAnnotationTrack {
 
     // Max resolution
     this.maxResolution = 4
+    this.geneticElements = [] // for tooltips 
   }
 
   tracksYPos (heightOrder) {
@@ -144,6 +136,10 @@ export class BaseAnnotationTrack {
     this.trackContainer.addEventListener('contextmenu',
       async (event) => {
         event.preventDefault()
+        // hide all tooltips
+        for (const element of this.geneticElements) {
+          hideTooltip(element.tooltip)
+        }
         // Toggle between expanded/collapsed view
         this.expanded = !this.expanded
         // set datastate for css

--- a/assets/js/track/base.test.js
+++ b/assets/js/track/base.test.js
@@ -1,30 +1,7 @@
 // Test tracks
-import { isElementOverlapping, isWithinElementBbox, calculateOffscreenWindowPos } from './base.js'
+import { calculateOffscreenWindowPos } from './base.js'
 import "regenerator-runtime/runtime";
 
-// Test overlapping elements
-describe('Test isElementOverlapping', () => {
-  test('first is within second', () => {
-    const first = {start: 100, end: 600}, second = {start: 50, end: 1000}
-    const resp = isElementOverlapping(first, second)
-    expect(resp).toBeTruthy()
-  })
-  test('first end is overapping second', () => {
-    const first = {start: 100, end: 600}, second = {start: 500, end: 1000}
-    const resp = isElementOverlapping(first, second)
-    expect(resp).toBeTruthy()
-  })
-  test('first start is overapping second', () => {
-    const first = {start: 100, end: 600}, second = {start: 20, end: 120}
-    const resp = isElementOverlapping(first, second)
-    expect(resp).toBeTruthy()
-  })
-  test('first start and second does not overlapp', () => {
-    const first = {start: 100, end: 200}, second = {start: 500, end: 900}
-    const resp = isElementOverlapping(first, second)
-    expect(resp).not.toBeTruthy()
-  })
-})
 
 // test that offscreen window position
 describe('Test calculateOffscreenWindowPos', () => {
@@ -35,21 +12,5 @@ describe('Test calculateOffscreenWindowPos', () => {
   test('test padding to region', () => {
     const region = calculateOffscreenWindowPos({start: 100, end: 200, multiplier: 2})
     expect(region).toEqual({start: 50, end: 250})
-  })
-})
-
-
-// test if point is within element
-describe('Test if point is within element', () => {
-  const element = {x1: 10, x2: 90, y1: -10, y2: 10}
-  test('test point within element bbox, xy', {
-    expect(isWithinElementBbox({element, point: {x: 20, y: 5}})).toBeTruthy()
-  })
-  test('test point is outside element bbox', {
-    expect(isWithinElementBbox({element, point: {x: 20, y: 5}})).toBeFalsy()
-  })
-  test('test point is on element bbox edge', {
-    expect(isWithinElementBbox({element, point: {x: 10, y: 10}})).toBeTruthy()
-    expect(isWithinElementBbox({element, point: {x: 50, y: 10}})).toBeTruthy()
   })
 })

--- a/assets/js/track/base.test.js
+++ b/assets/js/track/base.test.js
@@ -1,5 +1,5 @@
 // Test tracks
-import { isElementOverlapping, calculateOffscreenWindowPos } from './base.js'
+import { isElementOverlapping, isWithinElementBbox, calculateOffscreenWindowPos } from './base.js'
 import "regenerator-runtime/runtime";
 
 // Test overlapping elements
@@ -35,5 +35,21 @@ describe('Test calculateOffscreenWindowPos', () => {
   test('test padding to region', () => {
     const region = calculateOffscreenWindowPos({start: 100, end: 200, multiplier: 2})
     expect(region).toEqual({start: 50, end: 250})
+  })
+})
+
+
+// test if point is within element
+describe('Test if point is within element', () => {
+  const element = {x1: 10, x2: 90, y1: -10, y2: 10}
+  test('test point within element bbox, xy', {
+    expect(isWithinElementBbox({element, point: {x: 20, y: 5}})).toBeTruthy()
+  })
+  test('test point is outside element bbox', {
+    expect(isWithinElementBbox({element, point: {x: 20, y: 5}})).toBeFalsy()
+  })
+  test('test point is on element bbox edge', {
+    expect(isWithinElementBbox({element, point: {x: 10, y: 10}})).toBeTruthy()
+    expect(isWithinElementBbox({element, point: {x: 50, y: 10}})).toBeTruthy()
   })
 })

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -108,8 +108,8 @@ export function createTooltipElement ({id, title, information=[]}) {
 function tooltipHandler (event, track) {
   event.preventDefault()
   event.stopPropagation()
+  const point = { x: event.offsetX, y: event.offsetY }
   for (const element of track.geneticElements) {
-    const point = { x: event.offsetX, y: event.offsetY }
     const isInElement = isWithinElementBbox({
       element: {
         x1: element.visibleX1,
@@ -119,6 +119,7 @@ function tooltipHandler (event, track) {
       },
       point
     })
+    console.log('point', point, 'isInElement', isInElement, 'element', element)
     if (isInElement) {
       // check if pointer is in a feature of element
       let selectedFeature

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -2,7 +2,7 @@
 import { getVisibleXCoordinates, getVisibleYCoordinates, isWithinElementBbox } from './utils.js'
 
 // make virtual DOM element that represents a annoatation element
-export function makeVirtualDOMElement ({x1, x2, y1, y2, canvas}) {
+export function makeVirtualDOMElement ({ x1, x2, y1, y2, canvas }) {
   return { getBoundingClientRect: generateGetBoundingClientRect(x1, x2, y1, y2, canvas) }
 }
 
@@ -15,18 +15,7 @@ function generateGetBoundingClientRect (x1, x2, y1, y2, canvas) {
     top: y1 + Math.round(track.getBoundingClientRect().y),
     left: x1 + Math.round(track.getBoundingClientRect().x),
     right: x2 + Math.round(track.getBoundingClientRect().x),
-    bottom: y2 + Math.round(track.getBoundingClientRect().y),
-  })
-}
-
-function generateGetBoundingClientRectTest (x1, x2, y1, y2) {
-  return () => ({
-    top: 0,
-    left: 337,
-    bottom: 20,
-    right: 687,
-    width: 175,
-    height: 200,
+    bottom: y2 + Math.round(track.getBoundingClientRect().y)
   })
 }
 
@@ -77,7 +66,7 @@ export function createHtmlList (information) {
 }
 
 // create popover html element with message
-export function createTooltipElement ({id, title, information=[]}) {
+export function createTooltipElement ({ id, title, information = [] }) {
   // create popover base class
   const popover = document.createElement('div')
   popover.setAttribute('role', 'popover')
@@ -101,7 +90,6 @@ export function createTooltipElement ({id, title, information=[]}) {
   return popover
 }
 
-
 // function for handeling apperance and content of tooltips
 // element == a the main rendered element, a gene for instance
 // features == genetic sub components of the parent elements, for instance a exome
@@ -119,7 +107,6 @@ function tooltipHandler (event, track) {
       },
       point
     })
-    console.log('point', point, 'isInElement', isInElement, 'element', element)
     if (isInElement) {
       // check if pointer is in a feature of element
       let selectedFeature
@@ -170,9 +157,9 @@ function updateTooltipPos (track) {
     // update the virtual DOM element that defines the tooltip hitbox
     const xPos = track.contentCanvas.getBoundingClientRect().x
     element.tooltip.virtualElement = makeVirtualDOMElement({
-      x1: Math.round(element.visibleX1 + xPos), 
-      x2: Math.round(element.visibleX2 + xPos), 
-      y1: element.visibleY1, 
+      x1: Math.round(element.visibleX1 + xPos),
+      x2: Math.round(element.visibleX2 + xPos),
+      y1: element.visibleY1,
       y2: element.visibleY2
     })
     // update tooltip instance
@@ -181,8 +168,8 @@ function updateTooltipPos (track) {
 }
 
 // teardown tooltips generated for a track
-function teardownTooltips(track) {
-  while ( track.geneticElements.length ) {
+function teardownTooltips (track) {
+  while (track.geneticElements.length) {
     const element = track.geneticElements.shift()
     element.tooltip.instance.destroy() // kill popper
     track.trackContainer.querySelector(`#${element.tooltip.tooltip.id}`).remove()
@@ -200,13 +187,13 @@ export function initTrackTooltips (track) {
   track.trackContainer.addEventListener('mousemove', (e) => { tooltipHandler(e, track) })
   // extend drawOffScreenTrack to teardown old tooltips prior to drawing new
   const oldDrawOffscreenTrack = track.drawOffScreenTrack
-  track.drawOffScreenTrack = ({start_pos, end_pos, max_height_order, data}) => {
+  track.drawOffScreenTrack = ({ startPos, endPos, maxHeightOrder, data }) => {
     teardownTooltips(track)
-    oldDrawOffscreenTrack.call(track, {start_pos, end_pos, max_height_order, data})
+    oldDrawOffscreenTrack.call(track, { startPos, endPos, maxHeightOrder, data })
   }
   // extend instance function to recalculate positions of virtual dom elements
   const oldBlit = track.blitCanvas
-  track.blitCanvas = (start, end) => { 
+  track.blitCanvas = (start, end) => {
     updateTooltipPos(track)
     oldBlit.call(track, start, end)
   }

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -1,9 +1,8 @@
 // functions for handling tooltips
 import { getVisibleXCoordinates, getVisibleYCoordinates, isWithinElementBbox } from './utils.js'
 
-
 // make virtual DOM element that represents a annoatation element
-export function makeVirtualDOMElement(x1, x2, y1, y2) {
+export function makeVirtualDOMElement (x1, x2, y1, y2) {
   return { getBoundingClientRect: generateGetBoundingClientRect(x1, x2, y1, y2) }
 }
 
@@ -17,7 +16,7 @@ function generateGetBoundingClientRect (x1, x2, y1, y2) {
     top: y1,
     left: x2,
     right: x1,
-    bottom: y2,
+    bottom: y2
   })
 }
 
@@ -32,9 +31,9 @@ function generateGetBoundingClientRectTest (x1, x2, y1, y2) {
   })
 }
 
-export function updateVisableElementCoordinates ({element, canvas, screenPosition, scale}) {
-  const {x1, x2} = getVisibleXCoordinates({canvas: screenPosition, feature: element, scale: scale})
-  const {y1, y2} = getVisibleYCoordinates({canvas, element})
+export function updateVisableElementCoordinates ({ element, canvas, screenPosition, scale }) {
+  const { x1, x2 } = getVisibleXCoordinates({ canvas: screenPosition, feature: element, scale: scale })
+  const { y1, y2 } = getVisibleYCoordinates({ canvas, element })
   // update coordinates
   element.visibleX1 = x1
   element.visibleX2 = x2
@@ -52,7 +51,7 @@ function showTooltip ({ tooltip, feature }) {
   tooltip.isDisplayed = true
 }
 
-function hideFeatureInTooltip ({tooltip, feature}) {
+function hideFeatureInTooltip ({ tooltip, feature }) {
   const selectedFeature = tooltip.tooltip.querySelector(`#feature-${feature.id}`)
   selectedFeature.removeAttribute('data-show')
   feature.isDisplayed = false
@@ -80,7 +79,6 @@ export function createTooltipElement (message, id) {
   popover.innerHTML = message
   return popover
 }
-
 
 // function for handeling apperance and content of tooltips
 // element == a the main rendered element, a gene for instance
@@ -127,48 +125,45 @@ function tooltipHandler (event, track) {
   }
 }
 
-
 // update tooltip position
-function updateTooltipPos(track) {
+function updateTooltipPos (track) {
   for (const element of track.geneticElements) {
     // update coordinates for the main element
     updateVisableElementCoordinates({
-      element, 
+      element,
       canvas: track.contentCanvas,
       screenPosition: track.onscreenPosition,
-      scale: track.offscreenPosition.scale,
+      scale: track.offscreenPosition.scale
     })
     // update coordinates for features on element
     for (const feature of element.features) {
       updateVisableElementCoordinates({
-        element: feature, 
+        element: feature,
         canvas: track.contentCanvas,
         screenPosition: track.onscreenPosition,
-        scale: track.offscreenPosition.scale,
+        scale: track.offscreenPosition.scale
       })
     }
     // update the virtual DOM element that defines the tooltip hitbox
     const xPos = Math.round(track.contentCanvas.getBoundingClientRect().x)
     element.tooltip.virtualElement = makeVirtualDOMElement(
       element.visibleX1 + xPos, element.visibleX2 + xPos, element.visibleY1, element.visibleY2
-    ) 
+    )
     // update tooltip instance
     element.tooltip.instance.update()
   }
 }
 
-
 // initialize event listeners for hover function
-export function initTrackTooltips(track) { 
+export function initTrackTooltips (track) {
   // when mouse is leaving track
-  track.trackContainer.addEventListener('mouseleave', 
-    () => { 
-      for (const element of track.geneticElements) 
-      { hideTooltip(element.tooltip) } 
-    }) 
+  track.trackContainer.addEventListener('mouseleave',
+    () => {
+      for (const element of track.geneticElements) { hideTooltip(element.tooltip) }
+    })
   // when mouse is leaving track
   track.trackContainer.addEventListener('mousemove', (e) => { tooltipHandler(e, track) })
   // extend instance function to recalculate positions of virtual dom elements
   const oldBlit = track.blitCanvas
-  track.blitCanvas = (start, end) => { updateTooltipPos(track); oldBlit.call(track, start, end)}
+  track.blitCanvas = (start, end) => { updateTooltipPos(track); oldBlit.call(track, start, end) }
 }

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -177,6 +177,7 @@ function teardownTooltips (track) {
   }
 }
 
+
 // initialize event listeners for hover function
 export function initTrackTooltips (track) {
   // when mouse is leaving track
@@ -188,9 +189,9 @@ export function initTrackTooltips (track) {
   track.trackContainer.addEventListener('mousemove', (e) => { tooltipHandler(e, track) })
   // extend drawOffScreenTrack to teardown old tooltips prior to drawing new
   const oldDrawOffscreenTrack = track.drawOffScreenTrack
-  track.drawOffScreenTrack = ({ startPos, endPos, maxHeightOrder, data }) => {
+  track.drawOffScreenTrack = async ({ startPos, endPos, maxHeightOrder, data }) => {
     teardownTooltips(track)
-    oldDrawOffscreenTrack.call(track, { startPos, endPos, maxHeightOrder, data })
+    await oldDrawOffscreenTrack.call(track, { startPos, endPos, maxHeightOrder, data })
   }
   // extend instance function to recalculate positions of virtual dom elements
   const oldBlit = track.blitCanvas

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -1,5 +1,46 @@
 // functions for handling tooltips
-import { isWithinElementBbox } from './base.js'
+import { getVisibleXCoordinates, getVisibleYCoordinates, isWithinElementBbox } from './utils.js'
+
+
+// make virtual DOM element that represents a annoatation element
+export function makeVirtualDOMElement(x1, x2, y1, y2) {
+  return { getBoundingClientRect: generateGetBoundingClientRect(x1, x2, y1, y2) }
+}
+
+// Make a virtual DOM element from a genetic element object
+function generateGetBoundingClientRect (x1, x2, y1, y2) {
+  return () => ({
+    width: Math.round(x2 - x1),
+    height: Math.round(y2 - y1),
+    // width: 0,
+    // height: 0,
+    top: y1,
+    left: x2,
+    right: x1,
+    bottom: y2,
+  })
+}
+
+function generateGetBoundingClientRectTest (x1, x2, y1, y2) {
+  return () => ({
+    width: 0,
+    height: 0,
+    top: y1,
+    bottom: y1,
+    right: x1,
+    left: x1
+  })
+}
+
+export function updateVisableElementCoordinates ({element, canvas, screenPosition, scale}) {
+  const {x1, x2} = getVisibleXCoordinates({canvas: screenPosition, feature: element, scale: scale})
+  const {y1, y2} = getVisibleYCoordinates({canvas, element})
+  // update coordinates
+  element.visibleX1 = x1
+  element.visibleX2 = x2
+  element.visibleY1 = y1
+  element.visibleY2 = y2
+}
 
 function showTooltip ({ tooltip, feature }) {
   tooltip.tooltip.setAttribute('data-show', '')
@@ -82,6 +123,37 @@ function tooltipHandler (event, track) {
     } else {
       hideTooltip(element.tooltip)
     }
+    element.tooltip.instance.update()
+  }
+}
+
+
+// update tooltip position
+function updateTooltipPos(track) {
+  for (const element of track.geneticElements) {
+    // update coordinates for the main element
+    updateVisableElementCoordinates({
+      element, 
+      canvas: track.contentCanvas,
+      screenPosition: track.onscreenPosition,
+      scale: track.offscreenPosition.scale,
+    })
+    // update coordinates for features on element
+    for (const feature of element.features) {
+      updateVisableElementCoordinates({
+        element: feature, 
+        canvas: track.contentCanvas,
+        screenPosition: track.onscreenPosition,
+        scale: track.offscreenPosition.scale,
+      })
+    }
+    // update the virtual DOM element that defines the tooltip hitbox
+    const xPos = Math.round(track.contentCanvas.getBoundingClientRect().x)
+    element.tooltip.virtualElement = makeVirtualDOMElement(
+      element.visibleX1 + xPos, element.visibleX2 + xPos, element.visibleY1, element.visibleY2
+    ) 
+    // update tooltip instance
+    element.tooltip.instance.update()
   }
 }
 
@@ -95,5 +167,8 @@ export function initTrackTooltips(track) {
       { hideTooltip(element.tooltip) } 
     }) 
   // when mouse is leaving track
-  track.trackContainer.addEventListener('mousemove', (e) => { tooltipHandler(e, track) }) 
+  track.trackContainer.addEventListener('mousemove', (e) => { tooltipHandler(e, track) })
+  // extend instance function to recalculate positions of virtual dom elements
+  const oldBlit = track.blitCanvas
+  track.blitCanvas = (start, end) => { updateTooltipPos(track); oldBlit.call(track, start, end)}
 }

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -1,17 +1,32 @@
 // functions for handling tooltips
+import { isWithinElementBbox } from './base.js'
 
-export function showTooltip(tooltip) {
+function showTooltip ({ tooltip, feature }) {
   tooltip.tooltip.setAttribute('data-show', '')
-  tooltip.isDisplayed = true 
+  if (feature !== undefined) {
+    const featureElement = tooltip.tooltip.querySelector(`#feature-${feature.id}`)
+    featureElement.setAttribute('data-show', '')
+    feature.isDisplayed = true
+  }
+  tooltip.isDisplayed = true
 }
 
-export function hideTooltip(tooltip) {
+function hideFeatureInTooltip ({tooltip, feature}) {
+  const selectedFeature = tooltip.tooltip.querySelector(`#feature-${feature.id}`)
+  selectedFeature.removeAttribute('data-show')
+  feature.isDisplayed = false
+}
+
+function hideTooltip (tooltip) {
   tooltip.tooltip.removeAttribute('data-show')
-  tooltip.isDisplayed = false 
+  for (const feature of tooltip.tooltip.querySelectorAll('.feature')) {
+    feature.removeAttribute('data-show')
+  }
+  tooltip.isDisplayed = false
 }
 
 // create popover html element with message
-export function createTooltipElement(message, id) {
+export function createTooltipElement (message, id) {
   // create popover base class
   const popover = document.createElement('div')
   popover.setAttribute('role', 'popover')
@@ -23,4 +38,62 @@ export function createTooltipElement(message, id) {
   // add message to div
   popover.innerHTML = message
   return popover
+}
+
+
+// function for handeling apperance and content of tooltips
+// element == a the main rendered element, a gene for instance
+// features == genetic sub components of the parent elements, for instance a exome
+function tooltipHandler (event, track) {
+  event.preventDefault()
+  event.stopPropagation()
+  for (const element of track.geneticElements) {
+    const point = { x: event.offsetX, y: event.offsetY }
+    const isInElement = isWithinElementBbox({
+      element: {
+        x1: element.visibleX1,
+        x2: element.visibleX2,
+        y1: element.y1,
+        y2: element.y2
+      },
+      point
+    })
+    if (isInElement) {
+      // check if pointer is in a feature of element
+      let selectedFeature
+      for (const feature of element.features) {
+        const isInFeature = isWithinElementBbox({
+          element: {
+            x1: feature.visibleX1,
+            x2: feature.visibleX2,
+            y1: feature.y1,
+            y2: feature.y2
+          },
+          point
+        })
+        if (isInFeature && !feature.isDisplayed) {
+          // show feature
+          selectedFeature = feature
+        } else if (!isInFeature && feature.isDisplayed) {
+          hideFeatureInTooltip({ tooltip: element.tooltip, feature })
+        }
+      }
+      showTooltip({ tooltip: element.tooltip, feature: selectedFeature })
+    } else {
+      hideTooltip(element.tooltip)
+    }
+  }
+}
+
+
+// initialize event listeners for hover function
+export function initTrackTooltips(track) { 
+  // when mouse is leaving track
+  track.trackContainer.addEventListener('mouseleave', 
+    () => { 
+      for (const element of track.geneticElements) 
+      { hideTooltip(element.tooltip) } 
+    }) 
+  // when mouse is leaving track
+  track.trackContainer.addEventListener('mousemove', (e) => { tooltipHandler(e, track) }) 
 }

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -6,8 +6,9 @@ export function makeVirtualDOMElement ({ x1, x2, y1, y2, canvas }) {
   return { getBoundingClientRect: generateGetBoundingClientRect(x1, x2, y1, y2, canvas) }
 }
 
+
 // Make a virtual DOM element from a genetic element object
-function generateGetBoundingClientRect (x1, x2, y1, y2, canvas) {
+export function generateGetBoundingClientRect (x1, x2, y1, y2, canvas) {
   const track = canvas
   return () => ({
     width: Math.round(x2 - x1),

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -180,6 +180,15 @@ function updateTooltipPos (track) {
   }
 }
 
+// teardown tooltips generated for a track
+function teardownTooltips(track) {
+  while ( track.geneticElements.length ) {
+    const element = track.geneticElements.shift()
+    element.tooltip.instance.destroy() // kill popper
+    track.trackContainer.querySelector(`#${element.tooltip.tooltip.id}`).remove()
+  }
+}
+
 // initialize event listeners for hover function
 export function initTrackTooltips (track) {
   // when mouse is leaving track
@@ -189,7 +198,16 @@ export function initTrackTooltips (track) {
     })
   // when mouse is leaving track
   track.trackContainer.addEventListener('mousemove', (e) => { tooltipHandler(e, track) })
+  // extend drawOffScreenTrack to teardown old tooltips prior to drawing new
+  const oldDrawOffscreenTrack = track.drawOffScreenTrack
+  track.drawOffScreenTrack = ({start_pos, end_pos, max_height_order, data}) => {
+    teardownTooltips(track)
+    oldDrawOffscreenTrack.call(track, {start_pos, end_pos, max_height_order, data})
+  }
   // extend instance function to recalculate positions of virtual dom elements
   const oldBlit = track.blitCanvas
-  track.blitCanvas = (start, end) => { updateTooltipPos(track); oldBlit.call(track, start, end) }
+  track.blitCanvas = (start, end) => { 
+    updateTooltipPos(track)
+    oldBlit.call(track, start, end)
+  }
 }

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -1,0 +1,26 @@
+// functions for handling tooltips
+
+export function showTooltip(tooltip) {
+  tooltip.tooltip.setAttribute('data-show', '')
+  tooltip.isDisplayed = true 
+}
+
+export function hideTooltip(tooltip) {
+  tooltip.tooltip.removeAttribute('data-show')
+  tooltip.isDisplayed = false 
+}
+
+// create popover html element with message
+export function createTooltipElement(message, id) {
+  // create popover base class
+  const popover = document.createElement('div')
+  popover.setAttribute('role', 'popover')
+  if (id !== undefined) {
+    popover.id = id
+  }
+  popover.classList.add('tooltip')
+  popover.setAttribute('role', 'popover')
+  // add message to div
+  popover.innerHTML = message
+  return popover
+}

--- a/assets/js/track/tooltip.js
+++ b/assets/js/track/tooltip.js
@@ -47,6 +47,7 @@ function hideFeatureInTooltip ({ tooltip, feature }) {
 }
 
 export function hideTooltip (tooltip) {
+  // skip if tooltip has not been rendered
   tooltip.tooltip.removeAttribute('data-show')
   for (const feature of tooltip.tooltip.querySelectorAll('.feature')) {
     feature.removeAttribute('data-show')
@@ -99,6 +100,9 @@ function tooltipHandler (event, track) {
   event.stopPropagation()
   const point = { x: event.offsetX, y: event.offsetY }
   for (const element of track.geneticElements) {
+    if ( !element.tooltip) {
+      continue
+    }
     const isInElement = isWithinElementBbox({
       element: {
         x1: element.visibleX1,
@@ -139,6 +143,10 @@ function tooltipHandler (event, track) {
 // update tooltip position
 function updateTooltipPos (track) {
   for (const element of track.geneticElements) {
+    // skip if tooltip has not been rendered
+    if ( !element.tooltip ) {
+      continue
+    }
     // update coordinates for the main element
     updateVisableElementCoordinates({
       element,
@@ -172,6 +180,10 @@ function updateTooltipPos (track) {
 function teardownTooltips (track) {
   while (track.geneticElements.length) {
     const element = track.geneticElements.shift()
+    // skip if tooltip has not been rendered
+    if ( !element.tooltip ) {
+      continue
+    }
     element.tooltip.instance.destroy() // kill popper
     track.trackContainer.querySelector(`#${element.tooltip.tooltip.id}`).remove()
   }
@@ -183,7 +195,9 @@ export function initTrackTooltips (track) {
   // when mouse is leaving track
   track.trackContainer.addEventListener('mouseleave',
     () => {
-      for (const element of track.geneticElements) { hideTooltip(element.tooltip) }
+      for (const element of track.geneticElements) { 
+        if (element.tooltip) hideTooltip(element.tooltip)
+      }
     })
   // when mouse is leaving track
   track.trackContainer.addEventListener('mousemove', (e) => { tooltipHandler(e, track) })

--- a/assets/js/track/transcript.js
+++ b/assets/js/track/transcript.js
@@ -95,7 +95,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
 
   // draw transcript figures
   async _drawTranscript (element, color, plotFormat,
-    drawName = true, drawAsArrow = false) {
+    drawName = true, drawAsArrow = false, addTooltip = true) {
     const canvasYPos = this.tracksYPos(element.height_order)
     const scale = this.offscreenPosition.scale
     // sizes
@@ -207,24 +207,28 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     ]
     if (element.refseq_id) { elementInfo.push({ title: 'refSeq', value: element.refseq_id }) }
     if (element.hgnc_id) { elementInfo.push({ title: 'hgnc', value: element.hgnc_id }) }
-    const tooltip = createTooltipElement({
-      id: `popover-${element.transcript_id}`,
-      title: transcriptObj.name,
-      information: elementInfo
-    })
-    // add features to element
-    addFeatures(element, tooltip)
-    // create tooltip
-    this.trackContainer.appendChild(tooltip)
-    transcriptObj.tooltip = {
-      instance: createPopper(virtualElement, tooltip, {
-        modifiers: [
-          { name: 'offset', options: { offset: [0, virtualElement.getBoundingClientRect().height] } }
-        ]
-      }),
-      virtualElement: virtualElement,
-      tooltip: tooltip,
-      isDisplayed: false
+    if ( addTooltip ) {
+      const tooltip = createTooltipElement({
+        id: `popover-${element.transcript_id}`,
+        title: transcriptObj.name,
+        information: elementInfo
+      })
+      // add features to element
+      addFeatures(element, tooltip)
+      // create tooltip
+      this.trackContainer.appendChild(tooltip)
+      transcriptObj.tooltip = {
+        instance: createPopper(virtualElement, tooltip, {
+          modifiers: [
+            { name: 'offset', options: { offset: [0, virtualElement.getBoundingClientRect().height] } }
+          ]
+        }),
+        virtualElement: virtualElement,
+        tooltip: tooltip,
+        isDisplayed: false
+      }
+    } else { 
+      transcriptObj.tooltip = false
     }
     return transcriptObj
   }
@@ -275,6 +279,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
 
     // Go through queryResults and draw appropriate symbols
     const drawGeneName = this.getResolution < 3
+    const drawTooltips = this.getResolution < 4
     const drawExons = this.getResolution < 4
     for (const transc of filteredTranscripts) {
       if (!this.expanded && transc.height_order !== 1) { continue }
@@ -288,7 +293,8 @@ export class TranscriptTrack extends BaseAnnotationTrack {
         color,
         plotFormat,
         drawGeneName, // if gene names should be drawn
-        !drawExons // if transcripts should be represented as arrows
+        !drawExons, // if transcripts should be represented as arrows
+        drawTooltips,  // if tooltips should be added
       )
       this.geneticElements.push(transcriptObj)
     }

--- a/assets/js/track/transcript.js
+++ b/assets/js/track/transcript.js
@@ -50,11 +50,11 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     this.maxResolution = 4
     // Define with of the elements
     this.geneLineWidth = 2
-    initTrackTooltips(this)
+    // initTrackTooltips(this)
   }
 
   // draw feature
-  _drawFeature (feature, queryResult, heightOrder, canvasYPos,
+  _drawFeature (feature, heightOrder, canvasYPos,
     color, plotFormat) {
     // Go trough feature list and draw geometries
     const titleMargin = plotFormat.titleMargin
@@ -98,7 +98,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
   }
 
   // draw transcript figures
-  async _drawTranscript (element, queryResult, color, plotFormat,
+  async _drawTranscript (element, color, plotFormat,
     drawName = true, drawAsArrow = false) {
     const canvasYPos = this.tracksYPos(element.height_order)
     const scale = this.offscreenPosition.scale
@@ -180,7 +180,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
       // draw features
       for (const feature of element.features) {
         const feature_obj = this._drawFeature(
-          feature, queryResult, element.height_order,
+          feature, element.height_order,
           canvasYPos, transcriptObj.color, plotFormat
         )
         if (feature_obj !== undefined) {
@@ -233,18 +233,18 @@ export class TranscriptTrack extends BaseAnnotationTrack {
   }
 
   //  Draws transcripts in given range
-  async drawOffScreenTrack (queryResult) {
+  async drawOffScreenTrack ({start_pos, end_pos, max_height_order, data}) {
     //    store positions used when rendering the canvas
     this.offscreenPosition = {
-      start: queryResult.start_pos,
-      end: queryResult.end_pos,
+      start: start_pos,
+      end: end_pos,
       scale: (this.drawCanvas.width /
-              (queryResult.end_pos - queryResult.start_pos))
+              (end_pos - start_pos))
     }
     this.geneticElements = []
 
     // Set needed height of visible canvas and transcript tooltips
-    this.setContainerHeight(queryResult.max_height_order)
+    this.setContainerHeight(max_height_order)
 
     // Keeps track of previous values
     this.heightOrderRecord = {
@@ -256,9 +256,9 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     // limit drawing of transcript to pre-defined resolutions
     let filteredTranscripts = []
     if (this.getResolution < this.maxResolution + 1) {
-      filteredTranscripts = queryResult.data.transcripts.filter(
+      filteredTranscripts = data.transcripts.filter(
         transc => isElementOverlapping(
-          transc, { start: queryResult.start_pos, end: queryResult.end_pos }
+          transc, { start: start_pos, end: end_pos }
         )
       )
     }
@@ -288,7 +288,8 @@ export class TranscriptTrack extends BaseAnnotationTrack {
         : this.colorSchema.strand_neg
       // test create some genetic elements and store them
       const transcriptObj = await this._drawTranscript(
-        transc, queryResult, color,
+        transc, 
+        color,
         plotFormat,
         drawGeneName, // if gene names should be drawn
         !drawExons // if transcripts should be represented as arrows

--- a/assets/js/track/transcript.js
+++ b/assets/js/track/transcript.js
@@ -52,8 +52,6 @@ function buildTooltipContent (elem) {
   return container
 }
 
-
-
 export class TranscriptTrack extends BaseAnnotationTrack {
   constructor (x, width, near, far, hgType, colorSchema) {
     // Dimensions of track canvas
@@ -109,7 +107,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
         y2: Math.round(y + height),
         isDisplayed: false,
         visibleX1: visibleCoords.x1,
-        visibleX2: visibleCoords.x2,
+        visibleX2: visibleCoords.x2
       }
       drawRect({
         ctx: this.drawCtx,
@@ -223,7 +221,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
       element: transcript_obj,
       canvas: this.contentCanvas,
       screenPosition: this.onscreenPosition,
-      scale: this.offscreenPosition.scale,
+      scale: this.offscreenPosition.scale
     })
     // make a virtual representation of the genetic element
     const virtualElement = makeVirtualDOMElement(

--- a/assets/js/track/transcript.js
+++ b/assets/js/track/transcript.js
@@ -208,7 +208,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     if (element.refseq_id) { elementInfo.push({ title: 'refSeq', value: element.refseq_id }) }
     if (element.hgnc_id) { elementInfo.push({ title: 'hgnc', value: element.hgnc_id }) }
     const tooltip = createTooltipElement({
-      id: `${element.transcript_id}-popover`,
+      id: `popover-${element.transcript_id}`,
       title: transcriptObj.name,
       information: elementInfo
     })

--- a/assets/js/track/transcript.js
+++ b/assets/js/track/transcript.js
@@ -6,9 +6,8 @@ import { createPopper } from '@popperjs/core'
 import { drawRect, drawLine, drawArrow, drawText } from '../draw.js'
 import { getVisibleXCoordinates, isElementOverlapping } from './utils.js'
 
-
 // add feature information to tooltipElement
-function addFeatures(elem, tooltipElement) {
+function addFeatures (elem, tooltipElement) {
   const body = tooltipElement.querySelector('ul')
   for (const feature of elem.features) {
     // divide and conquer
@@ -24,7 +23,6 @@ function addFeatures(elem, tooltipElement) {
     body.appendChild(featureContainer)
   }
 }
-
 
 export class TranscriptTrack extends BaseAnnotationTrack {
   constructor (x, width, near, far, hgType, colorSchema) {
@@ -50,15 +48,13 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     this.maxResolution = 4
     // Define with of the elements
     this.geneLineWidth = 2
-    // initTrackTooltips(this)
+    initTrackTooltips(this)
   }
 
   // draw feature
   _drawFeature (feature, heightOrder, canvasYPos,
     color, plotFormat) {
     // Go trough feature list and draw geometries
-    const titleMargin = plotFormat.titleMargin
-    const textYPos = this.tracksYPos(heightOrder)
     const scale = this.offscreenPosition.scale
     // store feature rendering information
     const x = scale * (feature.start - this.offscreenPosition.start)
@@ -71,7 +67,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
       const visibleCoords = getVisibleXCoordinates({
         canvas: this.onscreenPosition, feature: feature, scale: scale
       })
-      const feature_obj = {
+      const featureObj = {
         id: feature.exon_number,
         start: feature.start,
         end: feature.end,
@@ -85,15 +81,15 @@ export class TranscriptTrack extends BaseAnnotationTrack {
       }
       drawRect({
         ctx: this.drawCtx,
-        x: feature_obj.x1,
-        y: feature_obj.y1,
+        x: featureObj.x1,
+        y: featureObj.y1,
         width: width,
         height: height,
         lineWidth: 1,
         fillColor: color,
         open: false
       })
-      return feature_obj
+      return featureObj
     }
   }
 
@@ -104,7 +100,6 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     const scale = this.offscreenPosition.scale
     // sizes
     const textSize = plotFormat.textSize
-    const titleMargin = plotFormat.titleMargin
     // store element metadata
     const transcriptObj = {
       id: element.transcript_id,
@@ -179,12 +174,12 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     } else {
       // draw features
       for (const feature of element.features) {
-        const feature_obj = this._drawFeature(
+        const featureObj = this._drawFeature(
           feature, element.height_order,
           canvasYPos, transcriptObj.color, plotFormat
         )
-        if (feature_obj !== undefined) {
-          transcriptObj.features.push(feature_obj)
+        if (featureObj !== undefined) {
+          transcriptObj.features.push(featureObj)
         }
       }
       transcriptObj.y1 = Math.min(...transcriptObj.features.map(feat => feat.y1))
@@ -199,12 +194,14 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     })
     // make a virtual representation of the genetic element
     const virtualElement = makeVirtualDOMElement({
-      x1: transcriptObj.visibleX1, x2: transcriptObj.visibleX2,
-      y1: transcriptObj.visibleY1, y2: transcriptObj.visibleY2,
-      canvas: this.contentCanvas,
+      x1: transcriptObj.visibleX1,
+      x2: transcriptObj.visibleX2,
+      y1: transcriptObj.visibleY1,
+      y2: transcriptObj.visibleY2,
+      canvas: this.contentCanvas
     })
     // create a tooltip html element and append to DOM
-    let elementInfo = [
+    const elementInfo = [
       { title: element.chrom, value: `${element.start}-${element.end}` },
       { title: 'id', value: element.transcript_id }
     ]
@@ -213,7 +210,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     const tooltip = createTooltipElement({
       id: `${element.transcript_id}-popover`,
       title: transcriptObj.name,
-      information: elementInfo,
+      information: elementInfo
     })
     // add features to element
     addFeatures(element, tooltip)
@@ -233,18 +230,18 @@ export class TranscriptTrack extends BaseAnnotationTrack {
   }
 
   //  Draws transcripts in given range
-  async drawOffScreenTrack ({start_pos, end_pos, max_height_order, data}) {
+  async drawOffScreenTrack ({ startPos, endPos, maxHeightOrder, data }) {
     //    store positions used when rendering the canvas
     this.offscreenPosition = {
-      start: start_pos,
-      end: end_pos,
+      start: startPos,
+      end: endPos,
       scale: (this.drawCanvas.width /
-              (end_pos - start_pos))
+              (endPos - startPos))
     }
     this.geneticElements = []
 
     // Set needed height of visible canvas and transcript tooltips
-    this.setContainerHeight(max_height_order)
+    this.setContainerHeight(maxHeightOrder)
 
     // Keeps track of previous values
     this.heightOrderRecord = {
@@ -258,13 +255,13 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     if (this.getResolution < this.maxResolution + 1) {
       filteredTranscripts = data.transcripts.filter(
         transc => isElementOverlapping(
-          transc, { start: start_pos, end: end_pos }
+          transc, { start: startPos, end: endPos }
         )
       )
     }
     // dont show tracks with no data in them
     if (filteredTranscripts.length > 0) {
-      this.setContainerHeight(this.trackData.max_height_order)
+      this.setContainerHeight(this.trackData.maxHeightOrder)
     } else {
       this.setContainerHeight(0)
     }
@@ -282,13 +279,12 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     for (const transc of filteredTranscripts) {
       if (!this.expanded && transc.height_order !== 1) { continue }
       // draw base transcript
-      const canvasYPos = this.tracksYPos(transc.height_order)
       const color = transc.strand === '+'
         ? this.colorSchema.strand_pos
         : this.colorSchema.strand_neg
       // test create some genetic elements and store them
       const transcriptObj = await this._drawTranscript(
-        transc, 
+        transc,
         color,
         plotFormat,
         drawGeneName, // if gene names should be drawn

--- a/assets/js/track/transcript.js
+++ b/assets/js/track/transcript.js
@@ -261,7 +261,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     }
     // dont show tracks with no data in them
     if (filteredTranscripts.length > 0) {
-      this.setContainerHeight(this.trackData.maxHeightOrder)
+      this.setContainerHeight(this.trackData.max_height_order)
     } else {
       this.setContainerHeight(0)
     }

--- a/assets/js/track/transcript.js
+++ b/assets/js/track/transcript.js
@@ -1,7 +1,50 @@
 // Transcript definition
 
-import { BaseAnnotationTrack, isElementOverlapping, lightenColor } from './base.js'
+import { BaseAnnotationTrack, isWithinElementBbox, isElementOverlapping, lightenColor } from './base.js'
+import { showTooltip, hideTooltip, createTooltipElement } from './tooltip.js'
+import { createPopper } from '@popperjs/core'
 import { drawRect, drawLine, drawArrow, drawText } from '../draw.js'
+
+
+// make tooltip text
+function buildTooltipContent(elem, exon) {
+  const container = document.createElement('div')
+  container.classList.add('tooltip-content')
+  // add title
+  const title = document.createElement('h4')
+  title.innerText = elem.mane ? `${elem.gene_name} [${elem.mane}]` : elem.gene_name
+  container.appendChild(title)
+  // add body information
+  const body = document.createElement('ul')
+  let information = [
+    {title: elem.chrom, value: `${elem.start}-${elem.end}`},
+    {title: 'id', value: elem.transcript_id},
+  ]
+  if ( elem.refseq_id ) {information.push({title: 'refSeq', value: elem.refseq_id})}
+  if ( elem.hgnc_id ) {information.push({title: 'hgnc', value: elem.hgnc_id})}
+  for (const info of information) {
+    let li = document.createElement('li')
+    let bold = document.createElement('strong')
+    bold.innerText = info.title
+    li.innerText = bold.innerHTML += ` : ${info.value}`
+    body.appendChild(li)
+  }
+  container.appendChild(body)
+  return container
+}
+
+// Make a virtual DOM element from a genetic element object
+function generateGetBoundingClientRect(x1, x2, y1, y2) {
+  return () => ({
+    width: Math.round(x2 - x1),
+    height: Math.round(y2 - y1),
+    top: y1,
+    right: x1,
+    bottom: y2,
+    left: x2,
+  })
+}
+
 
 export class TranscriptTrack extends BaseAnnotationTrack {
   constructor (x, width, near, far, hgType, colorSchema) {
@@ -27,63 +70,116 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     this.maxResolution = 4
     // Define with of the elements
     this.geneLineWidth = 2
+    this.geneticElements = []
+    // setup listeners for hover function
+    this.trackContainer.addEventListener('mouseleave', 
+      (event) => {
+        for (const element of this.geneticElements) {
+          hideTooltip(element.tooltip)
+      }
+    })
+    this.trackContainer.addEventListener('mousemove', 
+      (event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        for (const element of this.geneticElements) {
+          const visableElem = {
+            x1: element.visibleX1, x2: element.visibleX2,
+            y1: element.y1, y2: element.y2
+          }
+          const point = {x: event.offsetX, y: event.offsetY}
+          if (element.tooltip.isDisplayed) {
+            if (!isWithinElementBbox({element: visableElem, point })) {
+              hideTooltip(element.tooltip)
+              element.tooltip.instance.update()
+            }
+          } else {
+            // check if element is being displayed or not
+            if ( isElementOverlapping(element, this.onscreenPosition) ) {
+              // check if mouse pointer is within displayed element
+              if (isWithinElementBbox({element: visableElem, point })) {
+                showTooltip(element.tooltip)
+                element.tooltip.instance.update()
+            }
+          }
+        }
+      }
+    })
   }
+  
 
   // draw feature
-  _drawFeature (feature, element, queryResult, canvasYPos, geneText,
+  _drawFeature (feature, queryResult, heightOrder, canvasYPos, geneText,
     color, plotFormat) {
     // Go trough feature list and draw geometries
     const titleMargin = plotFormat.titleMargin
-    const textYPos = this.tracksYPos(element.height_order)
-    let latestFeaturePos = element.start
+    const textYPos = this.tracksYPos(heightOrder)
     const scale = this.offscreenPosition.scale
-    for (const feature of element.features) {
-      latestFeaturePos = feature.end
-      // Draw the geometry that represents the feature
-      if (feature.feature === 'exon') {
-        // Add tooltip title for whole gene
-        // const exonText = `${geneText}
-        // ${"-".repeat(30)}
-        // Exon number: ${feature.exon_number}
-        // chr ${queryResult.chromosome}:${feature.start}-${feature.end}`;
-        // this.heightOrderRecord.latestTrackEnd = this.hoverText(
-        //   exonText,
-        //   `${titleMargin + scale * (feature.start - queryResult.queryStart)}px`,
-        //   `${titleMargin + textYPos - (this.featureHeight / 2)}px`,
-        //   `${scale * (feature.end - feature.start)}px`,
-        //   `${this.featureHeight}px`,
-        //   1,
-        //   this.heightOrderRecord.latestTrackEnd);
-        drawRect({
-          ctx: this.drawCtx,
-          x: scale * (feature.start - this.offscreenPosition.start),
-          y: canvasYPos - this.featureHeight / 2,
-          width: scale * (feature.end - feature.start),
-          height: this.featureHeight,
-          lineWidth: 1,
-          fillColor: color,
-          open: false
-        })
-      }
+    // store feature rendering information
+    const x = scale * (feature.start - this.offscreenPosition.start)
+    const y = canvasYPos - this.featureHeight / 2
+    const width = Math.round(scale * (feature.end - feature.start))
+    const height = Math.round(this.featureHeight)
+    
+    const feature_obj = {
+      name: feature.name,
+      id: feature.exon_number,
+      start: feature.start,
+      end: feature.end,
+      x1: Math.round(x),
+      x2: Math.round(x + width),
+      y1: Math.round(y),
+      y2: Math.round(y + height),
+      isDisplayed: false,
     }
+    // Draw the geometry that represents the feature
+    if (feature.feature === 'exon') {
+      // Add tooltip title for whole gene
+      // const exonText = `${geneText}
+      // ${"-".repeat(30)}
+      // Exon number: ${feature.exon_number}
+      // chr ${queryResult.chromosome}:${feature.start}-${feature.end}`;
+      // this.heightOrderRecord.latestTrackEnd = this.hoverText(
+      //   exonText,
+      //   `${titleMargin + scale * (feature.start - queryResult.queryStart)}px`,
+      //   `${titleMargin + textYPos - (this.featureHeight / 2)}px`,
+      //   `${scale * (feature.end - feature.start)}px`,
+      //   `${this.featureHeight}px`,
+      //   1,
+      //   this.heightOrderRecord.latestTrackEnd);
+      drawRect({
+        ctx: this.drawCtx,
+        x: feature_obj.x1,
+        y: feature_obj.y1,
+        width: width,
+        height: height,
+        lineWidth: 1,
+        fillColor: color,
+        open: false
+      })
+    }
+    return feature_obj
   }
 
   // draw transcript figures
   async _drawTranscript (element, queryResult, color, plotFormat,
     drawName = true, drawAsArrow = false) {
-    const geneName = element.gene_name
-    const transcriptID = element.transcript_id
-    const chrom = element.chrom
-    const trStart = element.start
-    const trEnd = element.end
     const canvasYPos = this.tracksYPos(element.height_order)
     const scale = this.offscreenPosition.scale
     // sizes
     const textSize = plotFormat.textSize
     const titleMargin = plotFormat.titleMargin
-    // lighten colors for MANE transcripts
-    const elementColor = element.mane ? lightenColor(color, 15) : color
-
+    // store element metadata
+    let transcript_obj = {
+      id: element.transcript_id,
+      chrom: element.chrom,
+      start: element.start,
+      end: element.end,
+      mane: element.mane,
+      scale: scale,
+      color: element.mane ? lightenColor(color, 15) : color, // lighten colors for MANE transcripts
+      features: [],
+    }
     // Keep track of latest track
     if (this.heightOrderRecord.latestHeight !== element.height_order) {
       this.heightOrderRecord = {
@@ -95,22 +191,28 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     // Draw a line to mark gene's length
     // cap lines at offscreen canvas start/end
     const displayedTrStart = Math.round(
-      (trStart > this.offscreenPosition.start
-        ? scale * (trStart - this.offscreenPosition.start)
+      (transcript_obj.start > this.offscreenPosition.start
+        ? scale * (transcript_obj.start - this.offscreenPosition.start)
         : 0)
     )
     const displayedTrEnd = Math.round(
-      (this.offscreenPosition.end > trEnd
-        ? scale * (trEnd - this.offscreenPosition.start)
+      (this.offscreenPosition.end > transcript_obj.end
+        ? scale * (transcript_obj.end - this.offscreenPosition.start)
         : this.offscreenPosition.end)
     )
+    // store start and end coordinates
+    transcript_obj.x1 = displayedTrStart
+    transcript_obj.x2 = displayedTrEnd
+    transcript_obj.y1 = canvasYPos - (this.geneLineWidth / 2)
+    transcript_obj.y2 = canvasYPos + (this.geneLineWidth / 2)
+    // draw transcript backbone
     drawLine({
       ctx: this.drawCtx,
       x: displayedTrStart,
       x2: displayedTrEnd,
       y: canvasYPos,
       y2: canvasYPos,
-      color: elementColor,
+      color: transcript_obj.color,
       lineWith: this.geneLineWidth // set width of the element
     })
     // Draw gene name
@@ -119,7 +221,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
       const mane = element.mane ? ' [MANE] ' : ''
       drawText({
         ctx: this.drawCtx,
-        text: `${geneName}${mane}${element.strand === '+' ? '→' : '←'}`,
+        text: `${transcript_obj.name}${mane}${element.strand === '+' ? '→' : '←'}`,
         x: Math.round(((displayedTrEnd - displayedTrStart) / 2) + displayedTrStart),
         y: textYPos + this.featureHeight,
         fontProp: textSize
@@ -128,13 +230,6 @@ export class TranscriptTrack extends BaseAnnotationTrack {
 
     // Set tooltip text
     let geneText = ''
-    if (element.mane === true) {
-      geneText = `${geneName} [MANE]\nchr${chrom}:${trStart}-${trEnd}\n` +
-      `id = ${transcriptID}\nrefseq_id = ${element.refseqID}\nhgnc = ${element.hgncID}`
-    } else {
-      geneText = `${geneName}\nchr${chrom}:${trStart}-${trEnd}\n` +
-      `id = ${transcriptID}`
-    }
 
     // draw arrows in gene
     if (drawAsArrow) {
@@ -145,16 +240,19 @@ export class TranscriptTrack extends BaseAnnotationTrack {
         dir: element.strand === '+' ? 1 : -1, // direction
         height: this.featureHeight / 2, // height
         lineWidth: this.geneLineWidth, // lineWidth
-        color: elementColor // color
+        color: transcript.color // color
       })
     } else {
       // draw features
       for (const feature of element.features) {
-        this._drawFeature(
-          feature, element, queryResult,
-          canvasYPos, geneText, elementColor, plotFormat
+        const feature_obj = this._drawFeature(
+          feature, queryResult, element.height_order,
+          canvasYPos, geneText, transcript_obj.color, plotFormat
         )
+        transcript_obj.features.push(feature_obj)
       }
+      transcript_obj.y1 = Math.min(...transcript_obj.features.map(feat => feat.y1))
+      transcript_obj.y2 = Math.max(...transcript_obj.features.map(feat => feat.y2))
     }
 
     // Add tooltip title for whole gene
@@ -167,6 +265,31 @@ export class TranscriptTrack extends BaseAnnotationTrack {
     //   0,
     //   this.heightOrderRecord.latestTrackEnd
     // );
+    // adapt coordinates to global screen coordinates from coorinates local to canvas
+    // create tooltip for transcript
+    transcript_obj.visibleX1 = Math.round((Math.max(0, transcript_obj.start - this.onscreenPosition.start) * transcript_obj.scale))
+    transcript_obj.visibleX2 = Math.round((Math.min(this.onscreenPosition.end, transcript_obj.end - this.onscreenPosition.start) * transcript_obj.scale))
+    const canvasBbox = this.contentCanvas.getBoundingClientRect()
+    transcript_obj.visibleY1 = Math.round(transcript_obj.y1 + canvasBbox.y)
+    transcript_obj.visibleY2 = Math.round(transcript_obj.y2 + canvasBbox.y)
+    const virtualElement = {
+      getBoundingClientRect: generateGetBoundingClientRect(
+        transcript_obj.visibleX1, transcript_obj.visibleX2, transcript_obj.visibleY1, transcript_obj.visibleY2,
+    )}
+    const tooltip = createTooltipElement(
+      buildTooltipContent(element).innerHTML,
+      `${element.id}-popover`
+    )
+    this.trackContainer.appendChild(tooltip)
+    transcript_obj.tooltip = {
+      instance: createPopper(virtualElement, tooltip, {modifiers: [
+        {name: 'offset', options: {offset: [0, virtualElement.getBoundingClientRect().height / 2]}},
+      ]}),
+      virtualElement: virtualElement,
+      tooltip: tooltip,
+      isDisplayed: false,
+    }
+    return transcript_obj
   }
 
   //  Draws transcripts in given range
@@ -178,6 +301,7 @@ export class TranscriptTrack extends BaseAnnotationTrack {
       scale: (this.drawCanvas.width /
               (queryResult.end_pos - queryResult.start_pos))
     }
+    this.geneticElements = []
 
     // Set needed height of visible canvas and transcript tooltips
     this.setContainerHeight(queryResult.max_height_order)
@@ -222,12 +346,14 @@ export class TranscriptTrack extends BaseAnnotationTrack {
       const color = transc.strand === '+'
         ? this.colorSchema.strand_pos
         : this.colorSchema.strand_neg
-      await this._drawTranscript(
+      // test create some genetic elements and store them
+      const transcript_obj = await this._drawTranscript(
         transc, queryResult, color,
         plotFormat,
         drawGeneName, // if gene names should be drawn
         !drawExons // if transcripts should be represented as arrows
       )
+      this.geneticElements.push(transcript_obj)
     }
   }
 }

--- a/assets/js/track/utils.js
+++ b/assets/js/track/utils.js
@@ -36,5 +36,9 @@ export function isElementOverlapping (first, second) {
 
 // check if point is within an element
 export function isWithinElementBbox ({ element, point }) {
+  const xCheck = (element.x1 < point.x && point.x < element.x2)
+  const yCheck = (element.y1 < point.y && point.y < element.y2)
+  console.log(`X: ${element.x1} < ${point.x} && ${point.x} < ${element.x2}; ${xCheck}`)
+  console.log(`Y: ${element.y1} < ${point.y} && ${point.y} < ${element.y2}; ${yCheck}`)
   return (element.x1 < point.x && point.x < element.x2) && (element.y1 < point.y && point.y < element.y2)
 }

--- a/assets/js/track/utils.js
+++ b/assets/js/track/utils.js
@@ -1,0 +1,41 @@
+// Utility functions
+
+export function getVisibleYCoordinates ({ canvas, element, minWidth = 4 }) {
+  const bbox = canvas.getBoundingClientRect()
+  let y1 = Math.round(element.y1 + bbox.y)
+  let y2 = Math.round(element.y2 + bbox.y)
+  if (y2 - y1 < minWidth) {
+    y1 = Math.round(y1 - (minWidth - (y2 - y1) / 2))
+    y2 = Math.round(y2 + (minWidth - (y2 - y1) / 2))
+  }
+  return { y1, y2 }
+}
+
+export function getVisibleXCoordinates ({ canvas, feature, scale, minWidth = 4 }) {
+  let x1 = Math.round((Math.max(0, feature.start - canvas.start)) * scale)
+  let x2 = Math.round((Math.min(canvas.end, feature.end - canvas.start)) * scale)
+  if (x2 - x1 < minWidth) {
+    x1 = Math.round(x1 - (minWidth - (x2 - x1) / 2))
+    x2 = Math.round(x2 + (minWidth - (x2 - x1) / 2))
+  }
+  return { x1, x2 }
+}
+
+// Check if two geometries are overlapping
+// each input is an object with start/ end coordinates
+// f          >----------------<
+// s   >---------<
+export function isElementOverlapping (first, second) {
+  if ((first.start > second.start && first.start < second.end) || //
+       (first.end > second.start && first.end < second.end) ||
+       (second.start > first.start && second.start < first.end) ||
+       (second.end > first.start && second.end < first.end)) {
+    return true
+  }
+  return false
+}
+
+// check if point is within an element
+export function isWithinElementBbox ({ element, point }) {
+  return (element.x1 < point.x && point.x < element.x2) && (element.y1 < point.y && point.y < element.y2)
+}

--- a/assets/js/track/utils.js
+++ b/assets/js/track/utils.js
@@ -3,9 +3,10 @@
 export function getVisibleYCoordinates ({ element, minHeight = 4 }) {
   let y1 = Math.round(element.y1)
   let y2 = Math.round(element.y2)
-  if (y2 - y1 < minHeight) {
-    y1 = Math.round(y1 - (minHeight - (y2 - y1) / 2))
-    y2 = Math.round(y2 + (minHeight - (y2 - y1) / 2))
+  const height = y2 - y1
+  if (height < minHeight) {
+    y1 = Math.round(y1 - ((minHeight - height) / 2))
+    y2 = Math.round(y2 + ((minHeight - height) / 2))
   }
   return { y1, y2 }
 }
@@ -36,9 +37,5 @@ export function isElementOverlapping (first, second) {
 
 // check if point is within an element
 export function isWithinElementBbox ({ element, point }) {
-  const xCheck = (element.x1 < point.x && point.x < element.x2)
-  const yCheck = (element.y1 < point.y && point.y < element.y2)
-  console.log(`X: ${element.x1} < ${point.x} && ${point.x} < ${element.x2}; ${xCheck}`)
-  console.log(`Y: ${element.y1} < ${point.y} && ${point.y} < ${element.y2}; ${yCheck}`)
   return (element.x1 < point.x && point.x < element.x2) && (element.y1 < point.y && point.y < element.y2)
 }

--- a/assets/js/track/utils.js
+++ b/assets/js/track/utils.js
@@ -1,12 +1,11 @@
 // Utility functions
 
-export function getVisibleYCoordinates ({ canvas, element, minWidth = 4 }) {
-  const bbox = canvas.getBoundingClientRect()
-  let y1 = Math.round(element.y1 + bbox.y)
-  let y2 = Math.round(element.y2 + bbox.y)
-  if (y2 - y1 < minWidth) {
-    y1 = Math.round(y1 - (minWidth - (y2 - y1) / 2))
-    y2 = Math.round(y2 + (minWidth - (y2 - y1) / 2))
+export function getVisibleYCoordinates ({ element, minHeight = 4 }) {
+  let y1 = Math.round(element.y1)
+  let y2 = Math.round(element.y2)
+  if (y2 - y1 < minHeight) {
+    y1 = Math.round(y1 - (minHeight - (y2 - y1) / 2))
+    y2 = Math.round(y2 + (minHeight - (y2 - y1) / 2))
   }
   return { y1, y2 }
 }

--- a/assets/js/track/utils.test.js
+++ b/assets/js/track/utils.test.js
@@ -1,0 +1,40 @@
+import { isElementOverlapping, isWithinElementBbox } from './utils.js'
+
+// Test overlapping elements
+describe('Test isElementOverlapping', () => {
+  test('first is within second', () => {
+    const first = {start: 100, end: 600}, second = {start: 50, end: 1000}
+    const resp = isElementOverlapping(first, second)
+    expect(resp).toBeTruthy()
+  })
+  test('first end is overapping second', () => {
+    const first = {start: 100, end: 600}, second = {start: 500, end: 1000}
+    const resp = isElementOverlapping(first, second)
+    expect(resp).toBeTruthy()
+  })
+  test('first start is overapping second', () => {
+    const first = {start: 100, end: 600}, second = {start: 20, end: 120}
+    const resp = isElementOverlapping(first, second)
+    expect(resp).toBeTruthy()
+  })
+  test('first start and second does not overlapp', () => {
+    const first = {start: 100, end: 200}, second = {start: 500, end: 900}
+    const resp = isElementOverlapping(first, second)
+    expect(resp).not.toBeTruthy()
+  })
+})
+
+// test if point is within element
+describe('Test if point is within element', () => {
+  const element = {x1: 10, x2: 90, y1: -10, y2: 10}
+  test('test point within element bbox, xy', () => {
+    expect(isWithinElementBbox({element, point: {x: 20, y: 5}})).toBeTruthy()
+  })
+  test('test point is outside element bbox', () =>{
+    expect(isWithinElementBbox({element, point: {x: 20, y: 15}})).toBeFalsy()
+  })
+  test('test point is on element bbox edge', () => {
+    expect(isWithinElementBbox({element, point: {x: 10, y: 10}})).toBeFalsy()
+    expect(isWithinElementBbox({element, point: {x: 50, y: 10}})).toBeFalsy()
+  })
+})

--- a/assets/js/track/utils.test.js
+++ b/assets/js/track/utils.test.js
@@ -1,4 +1,4 @@
-import { isElementOverlapping, isWithinElementBbox } from './utils.js'
+import { isElementOverlapping, isWithinElementBbox, getVisibleXCoordinates, getVisibleYCoordinates } from './utils.js'
 
 // Test overlapping elements
 describe('Test isElementOverlapping', () => {
@@ -36,5 +36,58 @@ describe('Test if point is within element', () => {
   test('test point is on element bbox edge', () => {
     expect(isWithinElementBbox({element, point: {x: 10, y: 10}})).toBeFalsy()
     expect(isWithinElementBbox({element, point: {x: 50, y: 10}})).toBeFalsy()
+  })
+})
+
+// test getVisibleYCoordinates function
+describe('Test getVisibleYCoordinates', () => {
+  test('test element higher than minHeight', () => {
+    const element = {y1: 10, y2: 40}
+    const resp = getVisibleYCoordinates({ element, minHeight: 4 })
+    expect(resp).toEqual({ y1: 10, y2: 40 })
+  })
+
+  test('test element shorter than minHeight', () => {
+    const element = {y1: 10, y2: 20}
+    const resp = getVisibleYCoordinates({ element, minHeight: 20 })
+    expect(resp).toEqual({ y1: 5, y2: 25 })
+  })
+})
+
+// test getVisibleXCoordinates function
+describe('Test getVisibleXCoordinates', () => {
+  const canvas = {start: 100, end: 200}
+  const scale = 0.1
+
+  test('test feature inside visable canvas', () => {
+    const feature = {start: 120, end: 150}
+    const resp = getVisibleXCoordinates({ 
+      canvas, feature, scale, minWidth: 1
+    })
+    expect(resp).toEqual({ x1: 2, x2: 5 })
+  })
+
+  test('test feature inside visable canvas, no scale', () => {
+    const feature = {start: 120, end: 150}
+    const resp = getVisibleXCoordinates({ 
+      canvas, feature, scale: 1, minWidth: 1
+    })
+    expect(resp).toEqual({ x1: 20, x2: 50 })
+  })
+
+  test('test feature partly inside visable canvas, caped at begining', () => {
+    const feature = {start: 90, end: 150}
+    const resp = getVisibleXCoordinates({ 
+      canvas, feature, scale: 1, minWidth: 1
+    })
+    expect(resp).toEqual({ x1: 0, x2: 50 })
+  })
+
+  test('test feature partly inside visable canvas, caped at end', () => {
+    const feature = {start: 120, end: 600}
+    const resp = getVisibleXCoordinates({ 
+      canvas, feature, scale: 1, minWidth: 1
+    })
+    expect(resp).toEqual({ x1: 20, x2: 200 })
   })
 })

--- a/assets/js/track/variant.js
+++ b/assets/js/track/variant.js
@@ -53,21 +53,20 @@ export class VariantTrack extends BaseAnnotationTrack {
     })
   }
 
-  async drawOffScreenTrack (queryResult) {
+  async drawOffScreenTrack ({start_pos, end_pos, max_height_order, data}) {
     //  Draws variants in given range
-    const titleMargin = 2
     const textSize = 10
     // store positions used when rendering the canvas
     this.offscreenPosition = {
-      start: queryResult.start_pos,
-      end: queryResult.end_pos,
+      start: start_pos,
+      end: end_pos,
       scale: this.drawCanvas.width /
-        (queryResult.end_pos - queryResult.start_pos)
+        (end_pos - start_pos)
     }
     const scale = this.offscreenPosition.scale
 
     // Set needed height of visible canvas and transcript tooltips
-    this.setContainerHeight(queryResult.max_height_order)
+    this.setContainerHeight(max_height_order)
 
     // Keeps track of previous values
     this.heightOrderRecord = {
@@ -79,12 +78,11 @@ export class VariantTrack extends BaseAnnotationTrack {
     // limit drawing of annotations to pre-defined resolutions
     let filteredVariants = []
     if (this.getResolution < this.maxResolution + 1) {
-      filteredVariants = queryResult
-        .data
+      filteredVariants = data
         .variants
         .filter(variant => isElementOverlapping(
           { start: variant.position, end: variant.end },
-          { start: queryResult.start_pos, end: queryResult.end_pos }))
+          { start: start_pos, end: end_pos }))
     }
     // dont show tracks with no data in them
     if (filteredVariants.length > 0 &&
@@ -111,7 +109,7 @@ export class VariantTrack extends BaseAnnotationTrack {
       // create variant object
       const featureHeight = variantCategory == 'del' ? 7 : 8
       const variantObj = {
-        id: variant.varian_id,
+        id: variant.variant_id,
         name: variant.display_name,
         start: variant.position,
         end: variant.end,

--- a/assets/js/track/variant.js
+++ b/assets/js/track/variant.js
@@ -95,6 +95,7 @@ export class VariantTrack extends BaseAnnotationTrack {
     this.clearTracks()
 
     // Draw track
+    const drawTooltips = this.getResolution < 4
     for (const variant of filteredVariants) {
       const variantCategory = variant.sub_category // del, dup, sv, str
       const variantType = variant.variant_type
@@ -118,7 +119,8 @@ export class VariantTrack extends BaseAnnotationTrack {
         y1: canvasYPos,
         y2: Math.round((canvasYPos + featureHeight)),
         features: [],
-        isDisplayed: false
+        isDisplayed: false,
+        tooltip: false,
       }
       // get onscreen positions for offscreen xy coordinates
       updateVisableElementCoordinates({
@@ -127,38 +129,39 @@ export class VariantTrack extends BaseAnnotationTrack {
         scale: this.offscreenPosition.scale
       })
       // create a tooltip html element and append to DOM
-      // VARIANT_TR_TABLE[variantCategory]
-      const tooltip = createTooltipElement({
-        id: `popover-${variantObj.id}`,
-        title: `${variantType.toUpperCase()}: ${variant.category} - ${VARIANT_TR_TABLE[variantCategory]}`,
-        information: [
-          { title: 'Type', value: variant.category },
-          { title: variant.chromosome, value: `${variant.position}` },
-          { title: 'Ref', value: `${variant.reference}` },
-          { title: 'Alt', value: `${variant.alternative}` },
-          { title: 'Cytoband start/end', value: `${variant.cytoband_start}/${variant.cytoband_end}` },
-          { title: 'Quality', value: `${variant.quality}` }
-        ]
-      })
-      this.trackContainer.appendChild(tooltip)
-      // make a  virtual element as tooltip hitbox
-      const virtualElement = makeVirtualDOMElement({
-        x1: variantObj.visibleX1,
-        x2: variantObj.visibleX2,
-        y1: variantObj.visibleY1,
-        y2: variantObj.visibleY2,
-        canvas: this.contentCanvas
-      })
-      // add tooltip to variantObj
-      variantObj.tooltip = {
-        instance: createPopper(virtualElement, tooltip, {
-          modifiers: [
-            { name: 'offset', options: { offset: [0, virtualElement.getBoundingClientRect().height] } }
+      if ( drawTooltips ) {
+        const tooltip = createTooltipElement({
+          id: `popover-${variantObj.id}`,
+          title: `${variantType.toUpperCase()}: ${variant.category} - ${VARIANT_TR_TABLE[variantCategory]}`,
+          information: [
+            { title: 'Type', value: variant.category },
+            { title: variant.chromosome, value: `${variant.position}` },
+            { title: 'Ref', value: `${variant.reference}` },
+            { title: 'Alt', value: `${variant.alternative}` },
+            { title: 'Cytoband start/end', value: `${variant.cytoband_start}/${variant.cytoband_end}` },
+            { title: 'Quality', value: `${variant.quality}` }
           ]
-        }),
-        virtualElement: virtualElement,
-        tooltip: tooltip,
-        isDisplayed: false
+        })
+        this.trackContainer.appendChild(tooltip)
+        // make a  virtual element as tooltip hitbox
+        const virtualElement = makeVirtualDOMElement({
+          x1: variantObj.visibleX1,
+          x2: variantObj.visibleX2,
+          y1: variantObj.visibleY1,
+          y2: variantObj.visibleY2,
+          canvas: this.contentCanvas
+        })
+        // add tooltip to variantObj
+        variantObj.tooltip = {
+          instance: createPopper(virtualElement, tooltip, {
+            modifiers: [
+              { name: 'offset', options: { offset: [0, virtualElement.getBoundingClientRect().height] } }
+            ]
+          }),
+          virtualElement: virtualElement,
+          tooltip: tooltip,
+          isDisplayed: false
+        }
       }
       this.geneticElements.push(variantObj)
 

--- a/assets/js/track/variant.js
+++ b/assets/js/track/variant.js
@@ -227,24 +227,6 @@ export class VariantTrack extends BaseAnnotationTrack {
         y: textYPos + this.featureHeight,
         fontProp: textSize
       })
-
-      // Set tooltip text
-      // const variantText = `Id: ${variantName}\n` +
-        //                 `Position: ${chrom}:${variantStart}-${variantEnd}\n` +
-          //               `Type: ${variantType} ${variantCategory}\n` +
-            //             `Quality: ${quality}\n` +
-              //           `Rank score: ${rankScore}\n`
-
-      // Add tooltip title for whole gene
-      // this.heightOrderRecord.latestTrackEnd = this.hoverText(
-      //   variantText,
-      //   `${titleMargin + scale * (variantStart - this.offscreenPosition.start)}px`,
-      //   `${titleMargin + textYPos - this.featureHeight / 2}px`,
-      //   `${scale * (variantEnd - variantStart)}px`,
-      //   `${this.featureHeight + textSize}px`,
-      //   0,
-      //   this.heightOrderRecord.latestTrackEnd
-      // );
     }
   }
 }

--- a/assets/js/track/variant.js
+++ b/assets/js/track/variant.js
@@ -1,6 +1,7 @@
 // Variant track definition
 
-import { BaseAnnotationTrack, isElementOverlapping } from './base.js'
+import { BaseAnnotationTrack } from './base.js'
+import { isElementOverlapping } from './utils.js'
 import { drawRect, drawLine, drawWaveLine, drawText } from '../draw.js'
 
 // Draw variants

--- a/assets/js/track/variant.js
+++ b/assets/js/track/variant.js
@@ -88,7 +88,7 @@ export class VariantTrack extends BaseAnnotationTrack {
     if (filteredVariants.length > 0 &&
          this.getResolution < this.maxResolution + 1
     ) {
-      this.setContainerHeight(this.trackData.maxHeightOrder)
+      this.setContainerHeight(this.trackData.max_height_order)
     } else {
       this.setContainerHeight(0)
     }

--- a/assets/js/track/variant.js
+++ b/assets/js/track/variant.js
@@ -129,7 +129,7 @@ export class VariantTrack extends BaseAnnotationTrack {
       // create a tooltip html element and append to DOM
       // VARIANT_TR_TABLE[variantCategory]
       const tooltip = createTooltipElement({
-        id: `${variantObj.id}-popover`,
+        id: `popover-${variantObj.id}`,
         title: `${variantType.toUpperCase()}: ${variant.category} - ${VARIANT_TR_TABLE[variantCategory]}`,
         information: [
           { title: 'Type', value: variant.category },

--- a/assets/js/track/variant.js
+++ b/assets/js/track/variant.js
@@ -53,20 +53,20 @@ export class VariantTrack extends BaseAnnotationTrack {
     })
   }
 
-  async drawOffScreenTrack ({start_pos, end_pos, max_height_order, data}) {
+  async drawOffScreenTrack ({ startPos, endPos, maxHeightOrder, data }) {
     //  Draws variants in given range
     const textSize = 10
     // store positions used when rendering the canvas
     this.offscreenPosition = {
-      start: start_pos,
-      end: end_pos,
+      start: startPos,
+      end: endPos,
       scale: this.drawCanvas.width /
-        (end_pos - start_pos)
+        (endPos - startPos)
     }
     const scale = this.offscreenPosition.scale
 
     // Set needed height of visible canvas and transcript tooltips
-    this.setContainerHeight(max_height_order)
+    this.setContainerHeight(maxHeightOrder)
 
     // Keeps track of previous values
     this.heightOrderRecord = {
@@ -82,13 +82,13 @@ export class VariantTrack extends BaseAnnotationTrack {
         .variants
         .filter(variant => isElementOverlapping(
           { start: variant.position, end: variant.end },
-          { start: start_pos, end: end_pos }))
+          { start: startPos, end: endPos }))
     }
     // dont show tracks with no data in them
     if (filteredVariants.length > 0 &&
          this.getResolution < this.maxResolution + 1
     ) {
-      this.setContainerHeight(this.trackData.max_height_order)
+      this.setContainerHeight(this.trackData.maxHeightOrder)
     } else {
       this.setContainerHeight(0)
     }
@@ -107,7 +107,7 @@ export class VariantTrack extends BaseAnnotationTrack {
       if (!this.expanded && heightOrder !== 1) { continue }
 
       // create variant object
-      const featureHeight = variantCategory == 'del' ? 7 : 8
+      const featureHeight = variantCategory === 'del' ? 7 : 8
       const variantObj = {
         id: variant.variant_id,
         name: variant.display_name,
@@ -118,7 +118,7 @@ export class VariantTrack extends BaseAnnotationTrack {
         y1: canvasYPos,
         y2: Math.round((canvasYPos + featureHeight)),
         features: [],
-        isDisplayed: false,
+        isDisplayed: false
       }
       // get onscreen positions for offscreen xy coordinates
       updateVisableElementCoordinates({
@@ -127,7 +127,7 @@ export class VariantTrack extends BaseAnnotationTrack {
         scale: this.offscreenPosition.scale
       })
       // create a tooltip html element and append to DOM
-      //VARIANT_TR_TABLE[variantCategory]
+      // VARIANT_TR_TABLE[variantCategory]
       const tooltip = createTooltipElement({
         id: `${variantObj.id}-popover`,
         title: `${variantType.toUpperCase()}: ${variant.category} - ${VARIANT_TR_TABLE[variantCategory]}`,
@@ -137,8 +137,8 @@ export class VariantTrack extends BaseAnnotationTrack {
           { title: 'Ref', value: `${variant.reference}` },
           { title: 'Alt', value: `${variant.alternative}` },
           { title: 'Cytoband start/end', value: `${variant.cytoband_start}/${variant.cytoband_end}` },
-          { title: 'Quality', value: `${variant.quality}` },
-        ],
+          { title: 'Quality', value: `${variant.quality}` }
+        ]
       })
       this.trackContainer.appendChild(tooltip)
       // make a  virtual element as tooltip hitbox
@@ -147,7 +147,7 @@ export class VariantTrack extends BaseAnnotationTrack {
         x2: variantObj.visibleX2,
         y1: variantObj.visibleY1,
         y2: variantObj.visibleY2,
-        canvas: this.contentCanvas,
+        canvas: this.contentCanvas
       })
       // add tooltip to variantObj
       variantObj.tooltip = {

--- a/gens/blueprints/gens/templates/gens.html
+++ b/gens/blueprints/gens/templates/gens.html
@@ -168,7 +168,7 @@
     })
     Promise.all([ic.drawStaticContent(), oc.drawOverviewContent()]).then( () => {
         // setup event managers and draw the tracks
-        gens.drawTrack({chrom: '{{ chrom }}', start: start, end: {{ end}} })
+        gens.drawTrack({chrom: '{{ chrom }}', start: start, end: {{ end }} })
         document.dispatchEvent(new Event('data-loaded'))
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1959,6 +1959,11 @@
         }
       }
     },
+    "@popperjs/core": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@popperjs/core": "^2.9.2",
     "npm": "^7.5.4"
   },
   "name": "gens",


### PR DESCRIPTION
This PR re-implements tooltips

**How to test**:
1. Setup a demo instance of Gens
2. For each step, hover mouse pointer on annotated regions.
  - Navigate to: http://10.0.224.64:5003/643594?region=8:141468074-141468213&variant=84af935d282baeb23862b3c28670f9f9
  - Zoom out to display region, 8:141380052-141556319
  - Navigate to region, 8:143789474-143893570

**Expected outcome**:
- One tooltip per element should be displayed
- Tooltips should be centered on the segments of the elements that are visible
- Tooltips should contain relevant information
- For transcripts, the tooltip should display information on element features when hovering the mouse over them

**Review:**
- [ ] code approved by
