### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Added
+### Changed
+### Fixed
+
+## [2.0.0]
+### Added
  - Command line interface for manageing Gens
  - Commands for loading transcripts, annotations and chromosome size into database
  - Include api spec, html and static files in distribution

--- a/gens/__version__.py
+++ b/gens/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "1.2.1"
+VERSION = "2.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "npm": "^7.5.4"
   },
   "name": "gens",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Interactive tool to visualize genomic copy number profiles from WGS data",
   "main": "gens.js",
   "scripts": {

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ from setuptools import find_packages, setup
 
 setup(
     name="gens",
-    version="1.2.1",
+    version="2.0.0",
     description="Gens is a web-based interactive tool to visualize genomic copy number profiles from WGS data.",
     license="MIT",
-    author="Ronja",
+    author="Ronja, Markus Johansson",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
### Added
 - Command line interface for manageing Gens
 - Commands for loading transcripts, annotations and chromosome size into database
 - Include api spec, html and static files in distribution
 - Display when databases last updated in /about.html
 - Display current configuration /about.html
 - Added landing page that show uploaded samples
 - Added load sample command for loading samples into gens database
 - Added index command for creating new indexes
 - Added view sample command for displaying sample information
 - Added pagination samples table
### Changed
 - Changed development status from Alpha to Stable
 - Samples are loaded based on the paths given when uploading the sample
 - Gens no longer uses HG38_PATH and HG37_PATH variables
 - Use genome build instead of hg_type throughout the codebase and in API calls
### Fixed
 - Fixed typo in variable name