### PR TITLE
Release notes for version 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Added
+### Changed
+### Fixed
+
+## [2.1.0]
+### Added
  - Added seperate error page for when accessing a sample not in the database
  - load chromosome-info stores centromere position and cyto band info
  - Display viewed chromosome region in cytogenetic ideogram figure

--- a/gens/__version__.py
+++ b/gens/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "2.0.1"
+VERSION = "2.1.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "tippy.js": "^6.3.2"
   },
   "name": "gens",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Interactive tool to visualize genomic copy number profiles from WGS data",
   "main": "gens.js",
   "scripts": {


### PR DESCRIPTION
## [2.1.0]
### Added
 - Added seperate error page for when accessing a sample not in the database
 - load chromosome-info stores centromere position and cyto band info
 - Display viewed chromosome region in cytogenetic ideogram figure
### Changed
### Fixed
 - Can now display samples that doesnt have data on all chromosomes
