### PR TITLE
Changed Gens version 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 ### Changed
+### Fixed
+
+## [2.1.1]
+### Added
+### Changed
  - Updated flask and pinned connexion to v2
  - Updated node version of github action to 17.x
 ### Fixed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,9 @@
+[bumpversion]
+current_version = 2.1.1
+
 [metadata]
 description-file = README.md
 
 [flake8]
 max-line-length = 100
+

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="gens",
-    version="2.1.0",
+    version="2.1.1",
     description="Gens is a web-based interactive tool to visualize genomic copy number profiles from WGS data.",
     license="MIT",
     author="Ronja, Markus Johansson",


### PR DESCRIPTION
This PR updates Gens to version 2.1.1

### Added
### Changed
 - Updated flask and pinned connexion to v2
### Fixed
 - Fixed annotation tracks being hidden behind other elements
 - Increased contrast of region selector
 - Chromosome bands are displayed properly

