### PR TITLE
Fix caching to prevent displaying the wrong variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 ### Changed
+ - Changed cached method from simple to file system as it would be thread safe
+
 ### Fixed
+ - Fixed cache issue that could result in chromosome information not being updated
 
 ## [2.1.1]
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,6 @@ COPY --from=node-builder /usr/src/app/build/css/home.min.css /usr/src/app/build/
 COPY --from=node-builder /usr/src/app/build/*/gens.min.* gens/blueprints/gens/static/
 
 # make mountpoints and change ownership of app
-RUN mkdir -p /access /fs1/results && chown -R app:app /home/app/app /access /fs1
+RUN mkdir -p /access /fs1/results /fs1/results_dev && chown -R app:app /home/app/app /access /fs1 /fs1/results_dev
 # Change the user to app
 USER app

--- a/gens/blueprints/gens/views.py
+++ b/gens/blueprints/gens/views.py
@@ -23,7 +23,6 @@ gens_bp = Blueprint(
 
 
 @gens_bp.route("/<path:sample_name>", methods=["GET"])
-@cache.cached(timeout=60)
 def display_case(sample_name):
     """
     Renders the Gens template

--- a/gens/cache.py
+++ b/gens/cache.py
@@ -1,4 +1,6 @@
 """Initiate cachig for app."""
 from flask_caching import Cache
+import tempfile
 
-cache = Cache(config={"CACHE_TYPE": "FileSystemCache", "CACHE_DIR": "/tmp"})
+tmp_dir = tempfile.TemporaryDirectory(prefix="gens_cache_")
+cache = Cache(config={"CACHE_TYPE": "FileSystemCache", "CACHE_DIR": tmp_dir.name})

--- a/gens/cache.py
+++ b/gens/cache.py
@@ -1,4 +1,4 @@
 """Initiate cachig for app."""
 from flask_caching import Cache
 
-cache = Cache(config={"CACHE_TYPE": "simple"})
+cache = Cache(config={"CACHE_TYPE": "FileSystemCache", "CACHE_DIR": "/tmp"})


### PR DESCRIPTION
This PR fixes a bug that could cause the wrong to be displayed different regions were being displayed for the same case at the same time.

close #133 

**How to test**:
1. Use example variant in production Gens, http://cmdscout2.lund.skane.se/gens/24MD00143?region=6:32002301-32016300&variant=ee7d5522e87b70eb5bf525a6fce18104&genome_build=38&case_id=24MD00143&individual_id=24MD00143
2. Try repoducing the bug by first opening the variant in the production version of Gens.
3. Then change chromosome 6 to 8 in the url just after the page has loaded
4. Verify that the chromosome number has not changed to 8 and the variant is still being displayed.
5. Open the same variant in the dev version of Gens by replacing `gens` with `gens_dev` in the URL and repeat the steps above to reproduce the bug,

**Expected outcome**:
The new region and variant should be displayed.

**Review:**
- [ ] code approved by
