### PR TITLE
Fixed max args error when searching for genes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Fixed max arg error when searching for some genes
 
 ## [2.1.1]
 ### Added

--- a/gens/api.py
+++ b/gens/api.py
@@ -193,7 +193,7 @@ def search_annotation(query: str, genome_build, annotation_type):
         response_code = 404
     else:
         start_elem = elements[0]
-        end_elem = max(elements[1:], key=lambda elem: elem.get("end"))
+        end_elem = max(elements[0:], key=lambda elem: elem.get("end"))
         data = {
             "chromosome": start_elem.get("chrom"),
             "start_pos": start_elem.get("start"),


### PR DESCRIPTION
This PR fixes the `max() arg is an empty sequence` error when searching for an empty sequence in Gens.

**Review:**
- [ ] code approved by
