### PR TITLE
Fixed bug that prevented updating annotation tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+ - Fixed bug that prevented updating annotation tracks
 
 ## [2.1.2]
 ### Added

--- a/gens/db/annotation.py
+++ b/gens/db/annotation.py
@@ -22,7 +22,7 @@ def register_data_update(track_type, name=None):
     db = app.config["GENS_DB"][UPDATES]
     LOG.debug(f"Creating timestamp for {track_type}")
     track = {"track": track_type, "name": name}
-    db.remove(track)  # remove old track
+    db.delete_many(track)  # remove old track
     db.insert_one({**track, "timestamp": datetime.datetime.now()})
 
 


### PR DESCRIPTION
This PR replaces the deprecated `db.remove` with `db.delete_many`.
